### PR TITLE
Fix ArgumentParser fatalError in vectura-cli

### DIFF
--- a/Sources/VecturaCLI/VecturaCLI.swift
+++ b/Sources/VecturaCLI/VecturaCLI.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import VecturaKit
 
+@main
 struct VecturaCLI: AsyncParsableCommand {
   struct DocumentID: ExpressibleByArgument, Decodable {
     let uuid: UUID
@@ -288,5 +289,3 @@ extension VecturaCLI {
     }
   }
 }
-
-VecturaCLI.main()


### PR DESCRIPTION
I was having the following error when attempting to run `vectura-cli`:

```
ArgumentParser/ParsableCommand.swift:264: Fatal error:
--------------------------------------------------------------------
Asynchronous root command needs availability annotation.

The asynchronous root command `VecturaCLI` needs an availability
annotation in order to be executed asynchronously. To fix this issue,
add the following availability attribute to your `VecturaCLI`
declaration or set the minimum platform in your "Package.swift" file.

@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
--------------------------------------------------------------------
```

Turns out the issue was not with availability, but with how the cli was structured, with a `main.swift` file that manually called `VecturaCLI.main()` at the top level.

The solution was to rename `main.swift` to something else (`VecturaCLI.swift` in this case) and annotate the root `VecturaCLI` command structure with `@main`.