### PR TITLE
Adds support for loading models from a local directory

### DIFF
--- a/Sources/VecturaKit/VecturaKit.swift
+++ b/Sources/VecturaKit/VecturaKit.swift
@@ -172,7 +172,7 @@ public class VecturaKit: VecturaProtocol {
         query: String,
         numResults: Int? = nil,
         threshold: Float? = nil,
-        modelId: String = "sentence-transformers/all-MiniLM-L6-v2"
+        modelId: String = VecturaModelSource.defaultModelId
     ) async throws -> [VecturaSearchResult] {
         if bertModel == nil {
             bertModel = try await Bert.loadModelBundle(from: modelId)
@@ -277,11 +277,20 @@ public class VecturaKit: VecturaProtocol {
     public func updateDocument(
         id: UUID,
         newText: String,
-        modelId: String = "sentence-transformers/all-MiniLM-L6-v2"
+        model: VecturaModelSource = .default
     ) async throws {
         try await deleteDocuments(ids: [id])
 
-        _ = try await addDocument(text: newText, id: id, modelId: modelId)
+        _ = try await addDocument(text: newText, id: id, model: model)
+    }
+
+    @_disfavoredOverload
+    public func updateDocument(
+        id: UUID,
+        newText: String,
+        modelId: String = VecturaModelSource.defaultModelId
+    ) async throws {
+        try await updateDocument(id: id, newText: newText, model: .id(modelId))
     }
 
     // MARK: - Private

--- a/Sources/VecturaKit/VecturaModelSource.swift
+++ b/Sources/VecturaKit/VecturaModelSource.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Specifies where to obtain the resources for an embedding model.
+public enum VecturaModelSource: Sendable, CustomStringConvertible {
+    /// Automatically fetch the model from a remote repository based on its id.
+    case id(_ id: String)
+    /// Load a local model from the specified directory URL.
+    case folder(_ url: URL)
+}
+
+public extension VecturaModelSource {
+    /// The default model identifier when not otherwise specified.
+    static let defaultModelId: String = "sentence-transformers/all-MiniLM-L6-v2"
+
+    /// The default model when not otherwise specified.
+    static let `default` = VecturaModelSource.id(VecturaModelSource.defaultModelId)
+}
+
+public extension VecturaModelSource {
+    var description: String {
+        switch self {
+        case .id(let id): id
+        case .folder(let url): url.path(percentEncoded: false)
+        }
+    }
+}

--- a/Sources/VecturaKit/VecturaProtocol.swift
+++ b/Sources/VecturaKit/VecturaProtocol.swift
@@ -48,7 +48,7 @@ public extension VecturaProtocol {
     /// - Returns: The ID of the added document.
     func addDocument(
         text: String,
-        id: UUID?,
+        id: UUID? = nil,
         model: VecturaModelSource = .default
     ) async throws -> UUID {
         let ids = try await addDocuments(
@@ -67,6 +67,7 @@ public extension VecturaProtocol {
     ///   - modelId: Identifier of the model to use for generating the embedding
     ///              (e.g., "sentence-transformers/all-MiniLM-L6-v2").
     /// - Returns: The ID of the added document.
+    @_disfavoredOverload
     func addDocument(
         text: String,
         id: UUID?,

--- a/Sources/VecturaKit/VecturaProtocol.swift
+++ b/Sources/VecturaKit/VecturaProtocol.swift
@@ -3,19 +3,19 @@ import Foundation
 /// A protocol defining the requirements for a vector database instance.
 public protocol VecturaProtocol {
 
-    /// Adds a document to the vector store by embedding text.
+    /// Adds multiple documents to the vector store in batch.
     ///
     /// - Parameters:
-    ///   - text: The text content of the document.
-    ///   - id: Optional unique identifier for the document.
-    ///   - modelId: Identifier of the model to use for generating the embedding
-    ///              (e.g., "sentence-transformers/all-MiniLM-L6-v2").
-    /// - Returns: The ID of the added document.
-    func addDocument(
-        text: String,
-        id: UUID?,
-        modelId: String
-    ) async throws -> UUID
+    ///   - texts: The text contents of the documents.
+    ///   - ids: Optional unique identifiers for the documents.
+    ///   - model: A ``VecturaModelSource`` specifying how to load the model.
+    ///              (e.g.,`.id("sentence-transformers/all-MiniLM-L6-v2")`).
+    /// - Returns: The IDs of the added documents.
+    func addDocuments(
+        texts: [String],
+        ids: [UUID]?,
+        model: VecturaModelSource
+    ) async throws -> [UUID]
 
     /// Searches for similar documents using a *pre-computed query embedding*.
     ///
@@ -32,4 +32,62 @@ public protocol VecturaProtocol {
 
     /// Removes all documents from the vector store.
     func reset() async throws
+}
+
+// MARK: - Default Implementations
+
+public extension VecturaProtocol {
+
+    /// Adds a document to the vector store by embedding text.
+    ///
+    /// - Parameters:
+    ///   - text: The text content of the document.
+    ///   - id: Optional unique identifier for the document.
+    ///   - model: A ``VecturaModelSource`` specifying how to load the model.
+    ///              (e.g.,`.id("sentence-transformers/all-MiniLM-L6-v2")`).
+    /// - Returns: The ID of the added document.
+    func addDocument(
+        text: String,
+        id: UUID?,
+        model: VecturaModelSource = .default
+    ) async throws -> UUID {
+        let ids = try await addDocuments(
+            texts: [text],
+            ids: id.map { [$0] },
+            model: model
+        )
+        return ids[0]
+    }
+
+    /// Adds a document to the vector store by embedding text.
+    ///
+    /// - Parameters:
+    ///   - text: The text content of the document.
+    ///   - id: Optional unique identifier for the document.
+    ///   - modelId: Identifier of the model to use for generating the embedding
+    ///              (e.g., "sentence-transformers/all-MiniLM-L6-v2").
+    /// - Returns: The ID of the added document.
+    func addDocument(
+        text: String,
+        id: UUID?,
+        modelId: String = VecturaModelSource.defaultModelId
+    ) async throws -> UUID {
+        try await addDocument(text: text, id: id, model: .id(modelId))
+    }
+
+    /// Adds multiple documents to the vector store in batch.
+    ///
+    /// - Parameters:
+    ///   - texts: The text contents of the documents.
+    ///   - ids: Optional unique identifiers for the documents.
+    ///   - modelId: Identifier of the model to use for generating the embedding
+    ///              (e.g.,`.id("sentence-transformers/all-MiniLM-L6-v2")`).
+    /// - Returns: The IDs of the added documents.
+    func addDocuments(
+        texts: [String],
+        ids: [UUID]? = nil,
+        modelId: String = VecturaModelSource.defaultModelId
+    ) async throws -> [UUID] {
+        try await addDocuments(texts: texts, ids: ids, model: .id(modelId))
+    }
 }


### PR DESCRIPTION
See #3 

This adds a new `VecturaModelSource` enum which can be used to specify the model by ID or by local directory URL.

### New API

The `addDocuments` API was updated to take a `model:` parameter. I also took the opportunity to simplify the implementation by basing all `addDocument(s)` variants on a single implementation of `addDocuments`.

I've also included new implementations of the `addDocument(text:id:modelId:)` and `addDocuments(texts:ids:modelId:)` APIs that just call the new one with `model: .id(modelId)` so that existing code won't break with these changes.

### Examples

```swift
// Load model from HuggingFace, just like it used to work:
try await vectura.addDocument(
    text: "Hello, World!", 
    model: .id("sentence-transformers/all-MiniLM-L6-v2")
)
```

```swift
// Load model from local model bundle directory
try await vectura.addDocument(
    text: "Hello, World!", 
    model: .folder(URL(filePath: "/Users/johndoe/MLModels/all-MiniLM-L6-v2"))
)
```