### PR TITLE
Add support for custom storage directory

### DIFF
--- a/Sources/VecturaKit/VecturaConfig.swift
+++ b/Sources/VecturaKit/VecturaConfig.swift
@@ -6,6 +6,10 @@ public struct VecturaConfig {
   /// The name of the database instance.
   public let name: String
 
+  /// A custom directory where the database should be stored.
+  /// Will be created if it doesn't exist, database contents are stored in a subdirectory named after ``name``.
+  public let directoryURL: URL?
+
   /// The dimension of vectors to be stored.
   public let dimension: Int
 
@@ -45,10 +49,12 @@ public struct VecturaConfig {
 
   public init(
     name: String,
+    directoryURL: URL? = nil,
     dimension: Int,
     searchOptions: SearchOptions = SearchOptions()
   ) {
     self.name = name
+    self.directoryURL = directoryURL
     self.dimension = dimension
     self.searchOptions = searchOptions
   }

--- a/Sources/VecturaKit/VecturaKit.swift
+++ b/Sources/VecturaKit/VecturaKit.swift
@@ -29,11 +29,21 @@ public class VecturaKit: VecturaProtocol {
         self.config = config
         self.documents = [:]
 
-        // Create storage directory
-        self.storageDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-            .first!
-            .appendingPathComponent("VecturaKit")
-            .appendingPathComponent(config.name)
+        if let customStorageDirectory = config.directoryURL {
+            let databaseDirectory = customStorageDirectory.appending(path: config.name)
+
+            if !FileManager.default.fileExists(atPath: databaseDirectory.path(percentEncoded: false)) {
+                try FileManager.default.createDirectory(at: databaseDirectory, withIntermediateDirectories: true)
+            }
+            
+            self.storageDirectory = databaseDirectory
+        } else {
+            // Create default storage directory
+            self.storageDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+                .first!
+                .appendingPathComponent("VecturaKit")
+                .appendingPathComponent(config.name)
+        }
 
         try FileManager.default.createDirectory(at: storageDirectory, withIntermediateDirectories: true)
 

--- a/Tests/VecturaKitTests/VecturaKitTests.swift
+++ b/Tests/VecturaKitTests/VecturaKitTests.swift
@@ -207,4 +207,17 @@ final class VecturaKitTests: XCTestCase {
     XCTAssertGreaterThanOrEqual(results.count, 2)
     XCTAssertTrue(results[0].score > results[1].score)
   }
+
+  func testCustomStorageDirectory() async throws {
+    let customDirectoryURL = URL(filePath: NSTemporaryDirectory()).appending(path: "VecturaKitTest")
+    defer { try? FileManager.default.removeItem(at: customDirectoryURL) }
+
+    let instance = try VecturaKit(config: .init(name: "test", directoryURL: customDirectoryURL, dimension: 384))
+    let text = "Test document"
+    let id = UUID()
+    _ = try await instance.addDocument(text: text, id: id)
+
+    let documentPath = customDirectoryURL.appending(path: "test/\(id).json").path(percentEncoded: false)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: documentPath), "Custom storage directory inserted document doesn't exist at \(documentPath)")
+  }
 }


### PR DESCRIPTION
See #3 

This adds a new property to `VecturaConfig` that can be used to customize the parent directory where the database will be stored. Database files are created in a subdirectory named after the database.

The default behavior remains the same: unless a custom `directoryURL` is specified, databases are stored in the Documents directory.