### PR TITLE
Fix MLX test crashes and improve error handling

### DIFF
--- a/Tests/VecturaKitTests/VecturaKitTests.swift
+++ b/Tests/VecturaKitTests/VecturaKitTests.swift
@@ -10,7 +10,7 @@ final class VecturaKitTests: XCTestCase {
     
     override func setUp() async throws {
         config = VecturaConfig(name: "test-db", dimension: 384)
-        vectura = try VecturaKit(config: config)
+        vectura = try await VecturaKit(config: config)
     }
     
     override func tearDown() async throws {
@@ -50,7 +50,7 @@ final class VecturaKitTests: XCTestCase {
         
         // Create new instance with same config
         let config = VecturaConfig(name: "test-db", dimension: 384)
-        let newVectura = try VecturaKit(config: config)
+        let newVectura = try await VecturaKit(config: config)
         
         // Search should work with new instance
         let results = try await newVectura.search(query: "Document")
@@ -103,7 +103,7 @@ final class VecturaKitTests: XCTestCase {
     func testDimensionMismatch() async throws {
         // Test with wrong dimension config
         let wrongConfig = VecturaConfig(name: "wrong-dim-db", dimension: 128)
-        let wrongVectura = try VecturaKit(config: wrongConfig)
+        let wrongVectura = try await VecturaKit(config: wrongConfig)
         
         let text = "Test document"
         
@@ -179,7 +179,7 @@ final class VecturaKitTests: XCTestCase {
         XCTAssertEqual(results.count, 0)
         
         // Create new instance and verify it's empty
-        let newVectura = try VecturaKit(config: config)
+        let newVectura = try await VecturaKit(config: config)
         let newResults = try await newVectura.search(query: text)
         XCTAssertEqual(newResults.count, 0)
     }
@@ -213,7 +213,7 @@ final class VecturaKitTests: XCTestCase {
         let customDirectoryURL = URL(filePath: NSTemporaryDirectory()).appending(path: "VecturaKitTest")
         defer { try? FileManager.default.removeItem(at: customDirectoryURL) }
         
-        let instance = try VecturaKit(config: .init(name: "test", directoryURL: customDirectoryURL, dimension: 384))
+        let instance = try await VecturaKit(config: .init(name: "test", directoryURL: customDirectoryURL, dimension: 384))
         let text = "Test document"
         let id = UUID()
         _ = try await instance.addDocument(text: text, id: id)


### PR DESCRIPTION
## Summary
- Fixes issue #21: MLX tests crashing with signal code 6
- Improves test robustness and error handling for MLX-related functionality
- Adds comprehensive Metal/MLX availability checks

## Changes Made
- **Fixed VecturaKitTests**: Updated to use async VecturaKit initializer
- **Enhanced MLX test error handling**: Added Metal device availability checks and graceful error handling
- **Improved test isolation**: Added unique test directory IDs to prevent conflicts
- **Better cleanup**: Enhanced test teardown with proper error handling
- **Documentation**: Added comprehensive comments explaining test requirements and proper execution methods

## Root Cause Analysis
The crashes were caused by missing Metal Toolchain and MLX device library initialization failures. The tests now:
1. Check Metal device availability before attempting MLX initialization
2. Gracefully skip tests with informative messages when MLX/Metal is unavailable
3. Handle MLX initialization errors instead of hard crashes

## Test Requirements
These tests require:
1. Metal device (GPU) availability
2. Metal Toolchain (install via: `xcodebuild -downloadComponent MetalToolchain`)
3. MLX device libraries to be available

## How to Test
Run tests with: `xcodebuild test -scheme VecturaMLXKitTests -destination 'platform=macOS'`
(`swift test` may not work due to Metal library compilation requirements)

🤖 Generated with [Claude Code](https://claude.ai/code)