### PR TITLE
Add documentCount property and getAllDocuments method to VecturaKit and VecturaMLXKit

### DIFF
--- a/Sources/VecturaKit/VecturaKit.swift
+++ b/Sources/VecturaKit/VecturaKit.swift
@@ -381,6 +381,19 @@ public class VecturaKit: VecturaProtocol {
         try await updateDocument(id: id, newText: newText, model: .id(modelId))
     }
 
+    // MARK: - Public Properties
+    
+    /// Returns the number of documents currently stored in the vector database.
+    public var documentCount: Int {
+        return documents.count
+    }
+    
+    /// Returns all documents currently stored in the vector database.
+    /// - Returns: Array of VecturaDocument objects
+    public func getAllDocuments() -> [VecturaDocument] {
+        return Array(documents.values)
+    }
+
     // MARK: - Private
 
     private func tensorToArray(_ tensor: MLTensor) async -> [Float] {

--- a/Sources/VecturaMLXKit/VecturaMLXKit.swift
+++ b/Sources/VecturaMLXKit/VecturaMLXKit.swift
@@ -152,6 +152,19 @@ public class VecturaMLXKit {
         }
     }
     
+    // MARK: - Public Properties
+    
+    /// Returns the number of documents currently stored in the vector database.
+    public var documentCount: Int {
+        return documents.count
+    }
+    
+    /// Returns all documents currently stored in the vector database.
+    /// - Returns: Array of VecturaDocument objects
+    public func getAllDocuments() -> [VecturaDocument] {
+        return Array(documents.values)
+    }
+
     // MARK: - Private
     
     private func loadDocuments() throws {


### PR DESCRIPTION
- Add documentCount property to return the number of documents stored
- Add getAllDocuments method to fetch all documents from the vector database
- Both methods are added to VecturaKit and VecturaMLXKit classes
- Addresses issue #30 by providing public API to check document count and fetch data