### PR TITLE
[codex] Pin swift-embeddings to stable 0.0.26

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jkrukowski/swift-embeddings.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33"
+        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33",
+        "version" : "0.0.26"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/jkrukowski/swift-embeddings.git", branch: "main"),
+    .package(url: "https://github.com/jkrukowski/swift-embeddings.git", from: "0.0.26"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   ],
   targets: [


### PR DESCRIPTION
## Summary
- replace the `swift-embeddings` branch dependency with the released `0.0.26` tag
- update `Package.resolved` to record the same revision as a stable version pin
- keep the effective dependency code unchanged while making the VecturaKit 5.x line consumable by downstream stable packages

## Why
`VecturaMLXKit` cannot move to a stable 2.x line on top of `VecturaKit` 5.x while `VecturaKit` itself depends on an unstable branch requirement. SwiftPM rejects downstream stable-version resolution in that configuration.

## Impact
- downstream packages can depend on future `VecturaKit` 5.x tags without tripping SwiftPM's stable-versus-unstable dependency check
- no functional behavior change is intended because `0.0.26` points at the revision the package was already locking

## Validation
- `swift package resolve`
- `swift build`
- `swift test`
- `swift run vectura-cli mock --db-name qa-db`
