### PR TITLE
Add VecturaOAIKit as a package target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,20 @@ let package = Package(
       targets: ["VecturaKit"]
     ),
     .library(
+      name: "VecturaOAIKit",
+      targets: ["VecturaOAIKit"]
+    ),
+    .library(
       name: "VecturaNLKit",
       targets: ["VecturaNLKit"]
     ),
     .executable(
       name: "vectura-cli",
       targets: ["VecturaCLI"]
+    ),
+    .executable(
+      name: "vectura-oai-cli",
+      targets: ["VecturaOAICLI"]
     ),
   ],
   dependencies: [
@@ -47,6 +55,12 @@ let package = Package(
         "VecturaKit"
       ]
     ),
+    .target(
+      name: "VecturaOAIKit",
+      dependencies: [
+        "VecturaKit"
+      ]
+    ),
     .executableTarget(
       name: "VecturaCLI",
       dependencies: [
@@ -58,8 +72,20 @@ let package = Package(
       ]
     ),
     .executableTarget(
+      name: "VecturaOAICLI",
+      dependencies: [
+        "VecturaKit",
+        "VecturaOAIKit",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]
+    ),
+    .executableTarget(
       name: "TestExamples",
       dependencies: ["VecturaKit"]
+    ),
+    .executableTarget(
+      name: "TestOAIExamples",
+      dependencies: ["VecturaOAIKit"]
     ),
     .executableTarget(
       name: "TestNLExamples",
@@ -72,6 +98,10 @@ let package = Package(
     .testTarget(
       name: "VecturaNLKitTests",
       dependencies: ["VecturaNLKit"]
+    ),
+    .testTarget(
+      name: "VecturaOAIKitTests",
+      dependencies: ["VecturaOAIKit"]
     ),
     .testTarget(
       name: "PerformanceTests",

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ VecturaKit is a Swift-based vector database designed for on-device apps through 
 
 Inspired by [Dripfarm's SVDB](https://github.com/Dripfarm/SVDB), **VecturaKit** uses `MLTensor` and [`swift-embeddings`](https://github.com/jkrukowski/swift-embeddings) for generating and managing embeddings. It features **Model2Vec** support with the 32M parameter model as default for fast static embeddings, and supports **NomicBERT**, **ModernBERT**, **RoBERTa**, and **XLM-RoBERTa** models.
 
-The framework offers `VecturaKit` as the core vector database with pluggable embedding providers. Use `SwiftEmbedder` for `swift-embeddings` integration, `NLContextualEmbedder` for Apple's NaturalLanguage framework with zero external dependencies, or [`MLXEmbedder`](https://github.com/rryam/VecturaMLXKit) for Apple's MLX framework acceleration (available as a separate package).
+The framework offers `VecturaKit` as the core vector database with pluggable embedding providers. Use `SwiftEmbedder` for `swift-embeddings` integration, `OpenAICompatibleEmbedder` for hosted or local `/v1/embeddings` providers, `NLContextualEmbedder` for Apple's NaturalLanguage framework with zero external dependencies, or [`MLXEmbedder`](https://github.com/rryam/VecturaMLXKit) for Apple's MLX framework acceleration (available as a separate package).
 
-It also includes a CLI tool (`vectura-cli`) for easily trying out the package.
+It also includes CLI tools (`vectura-cli` and `vectura-oai-cli`) for easily trying out the package.
 
 <p align="center">
   <img src="https://img.shields.io/badge/Swift-6.0+-fa7343?style=flat&logo=swift&logoColor=white" alt="Swift 6.0+">
@@ -51,6 +51,9 @@ Explore the following books to understand more about AI and iOS development:
   - [Custom Storage Provider](#custom-storage-provider)
   - [Custom Search Engine](#custom-search-engine)
 - [MLX Integration](#mlx-integration)
+- [OpenAI-Compatible Integration](#openai-compatible-integration)
+  - [Import OpenAI-Compatible Support](#import-openai-compatible-support)
+  - [Initialize Database with OpenAI-Compatible Embeddings](#initialize-database-with-openai-compatible-embeddings)
 - [NaturalLanguage Integration](#naturallanguage-integration)
   - [Import NaturalLanguage Support](#import-naturallanguage-support)
   - [Initialize Database with NLContextualEmbedding](#initialize-database-with-nlcontextualembedding)
@@ -59,6 +62,7 @@ Explore the following books to understand more about AI and iOS development:
   - [Document Management](#nl-document-management)
 - [Command Line Interface](#command-line-interface)
   - [Swift CLI Tool (`vectura-cli`)](#swift-cli-tool-vectura-cli)
+  - [OpenAI-Compatible CLI Tool (`vectura-oai-cli`)](#openai-compatible-cli-tool-vectura-oai-cli)
 - [License](#license)
 - [Contributing](#contributing)
 - [Support](#support)
@@ -80,8 +84,9 @@ Explore the following books to understand more about AI and iOS development:
 -   **Custom Storage Provider:** Implements custom storage backends (SQLite, Core Data, cloud storage) by conforming to the `VecturaStorage` protocol.
 -   **Memory Management Strategies:** Choose between automatic, full-memory, or indexed modes to optimize performance for datasets ranging from thousands to millions of documents. [Learn more](Docs/INDEXED_STORAGE_GUIDE.md)
 -   **MLX Support:** GPU-accelerated embedding generation available via the separate [VecturaMLXKit](https://github.com/rryam/VecturaMLXKit) package.
+-   **OpenAI-Compatible Support:** Connects to OpenAI-compatible `/v1/embeddings` endpoints exposed by local servers and hosted providers through `OpenAICompatibleEmbedder`.
 -   **NaturalLanguage Support:** Uses Apple's NaturalLanguage framework for contextual embeddings with zero external dependencies through `NLContextualEmbedder`.
--   **CLI Tool:** Includes `vectura-cli` for database management and testing.
+-   **CLI Tools:** Includes `vectura-cli` and `vectura-oai-cli` for database management and testing.
 
 ## Supported Platforms
 
@@ -103,6 +108,18 @@ dependencies: [
 ],
 ```
 
+Then add the products you want to your target:
+
+```swift
+target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "VecturaKit", package: "VecturaKit"),
+        .product(name: "VecturaOAIKit", package: "VecturaKit"),
+    ]
+)
+```
+
 For MLX support, also add the separate [VecturaMLXKit](https://github.com/rryam/VecturaMLXKit) package:
 
 ```swift
@@ -119,7 +136,7 @@ VecturaKit uses the following Swift packages:
 -   [swift-embeddings](https://github.com/jkrukowski/swift-embeddings): Used in `VecturaKit` for generating text embeddings using various models.
 -   [swift-argument-parser](https://github.com/apple/swift-argument-parser): Used for creating the command-line interface.
 
-**Note:** `VecturaNLKit` has no external dependencies beyond Apple's native NaturalLanguage framework. For MLX-based embeddings, see [VecturaMLXKit](https://github.com/rryam/VecturaMLXKit).
+**Note:** `VecturaNLKit` and `VecturaOAIKit` are shipped from this package. The standalone `VecturaOAIKit` repository is intended to be deprecated after this integration lands. For MLX-based embeddings, see [VecturaMLXKit](https://github.com/rryam/VecturaMLXKit).
 
 ## Quick Start
 
@@ -454,6 +471,44 @@ For GPU-accelerated embeddings using Apple's MLX framework, see the separate [Ve
 .package(url: "https://github.com/rryam/VecturaMLXKit.git", from: "1.0.0"),
 ```
 
+## OpenAI-Compatible Integration
+
+VecturaKit supports OpenAI-compatible embedding APIs through `OpenAICompatibleEmbedder`. This is useful for local servers such as Ollama, LM Studio, llama.cpp-compatible servers, vLLM, and hosted providers that expose `/v1/embeddings`.
+
+### Import OpenAI-Compatible Support
+
+```swift
+import VecturaKit
+import VecturaOAIKit
+```
+
+### Initialize Database with OpenAI-Compatible Embeddings
+
+```swift
+let config = VecturaConfig(
+  name: "my-oai-vector-db",
+  dimension: nil
+)
+
+let embedder = OpenAICompatibleEmbedder(
+  baseURL: "http://localhost:1234/v1",
+  model: "text-embedding-model",
+  apiKey: nil,
+  timeoutInterval: 120,
+  retryAttempts: 2,
+  retryBaseDelaySeconds: 1
+)
+
+let vectorDB = try await VecturaKit(config: config, embedder: embedder)
+```
+
+The embedder:
+
+- Sends batched requests to `POST <baseURL>/embeddings`
+- Adds `Authorization: Bearer ...` when an API key is configured
+- Retries HTTP 429 responses and honors `Retry-After` when present
+- Detects embedding dimension automatically on first use
+
 ## NaturalLanguage Integration
 
 VecturaKit supports Apple's NaturalLanguage framework through the `NLContextualEmbedder` for contextual embeddings with zero external dependencies.
@@ -612,6 +667,32 @@ Common options for `vectura-cli`:
 -   `--threshold, -t`: Minimum similarity threshold (default: 0.7)
 -   `--num-results, -n`: Number of results to return (default: 10)
 -   `--model-id, -m`: Model ID for embeddings (default: "minishlab/potion-base-4M")
+
+### OpenAI-Compatible CLI Tool (`vectura-oai-cli`)
+
+Set `VECTURA_OAI_BASE_URL` and `VECTURA_OAI_MODEL`, or pass `--base-url` and `--model` directly.
+
+```bash
+vectura-oai add "First document" "Second document" --model text-embedding-model
+vectura-oai search "search query" --model text-embedding-model --threshold 0.7 --num-results 5
+vectura-oai update <document-uuid> "Updated text" --model text-embedding-model
+vectura-oai delete <document-uuid-1> <document-uuid-2> --model text-embedding-model
+vectura-oai reset --model text-embedding-model
+vectura-oai mock --model text-embedding-model
+```
+
+Common options for `vectura-oai-cli`:
+
+-   `--db-name, -d`: Database name (default: `"vectura-oai-cli-db"`)
+-   `--directory`: Database directory (optional)
+-   `--base-url`: OpenAI-compatible base URL
+-   `--model`: Embedding model identifier
+-   `--api-key`: Optional API key
+-   `--timeout`: Request timeout in seconds
+-   `--retry-attempts`: HTTP 429 retry attempts
+-   `--retry-base-delay`: Base retry delay in seconds
+-   `--threshold, -t`: Minimum similarity threshold (default: `0.7`)
+-   `--num-results, -n`: Number of results to return (default: `10`)
 
 ## License
 

--- a/Sources/TestOAIExamples/TestOAIExamples.swift
+++ b/Sources/TestOAIExamples/TestOAIExamples.swift
@@ -1,0 +1,67 @@
+import Foundation
+import VecturaKit
+import VecturaOAIKit
+
+@main
+struct TestOAIExamples {
+    static func main() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        let baseURL = environment["VECTURA_OAI_BASE_URL"] ?? "http://localhost:1234/v1"
+        let model = environment["VECTURA_OAI_MODEL"] ?? ""
+        let apiKey = environment["VECTURA_OAI_API_KEY"]
+
+        guard !model.isEmpty else {
+            throw NSError(
+                domain: "TestOAIExamples",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Set VECTURA_OAI_MODEL before running the example."]
+            )
+        }
+
+        debugPrint("Testing VecturaOAIKit examples")
+
+        let config = try VecturaConfig(
+            name: "test-oai-vector-db"
+        )
+        let vectorDB = try await VecturaKit(
+            config: config,
+            embedder: OpenAICompatibleEmbedder(
+                baseURL: baseURL,
+                model: model,
+                apiKey: apiKey,
+                timeoutInterval: 120,
+                retryAttempts: 2,
+                retryBaseDelaySeconds: 1
+            )
+        )
+
+        let texts = [
+            "First document text",
+            "Second document text",
+            "Third document text",
+        ]
+        let documentIDs = try await vectorDB.addDocuments(texts: texts)
+        debugPrint("Documents added with IDs: \(documentIDs)")
+
+        let results = try await vectorDB.search(
+            query: "document text",
+            numResults: 5,
+            threshold: 0.8
+        )
+
+        debugPrint("Search found \(results.count) results:")
+        for result in results {
+            debugPrint("ID: \(result.id)")
+            debugPrint("Text: \(result.text)")
+            debugPrint("Score: \(result.score)")
+            debugPrint("Created At: \(result.createdAt)")
+        }
+
+        if let documentToUpdate = documentIDs.first {
+            try await vectorDB.updateDocument(id: documentToUpdate, newText: "Updated text")
+        }
+
+        try await vectorDB.reset()
+        debugPrint("Database reset")
+    }
+}

--- a/Sources/VecturaOAICLI/VecturaOAICLI.swift
+++ b/Sources/VecturaOAICLI/VecturaOAICLI.swift
@@ -1,0 +1,322 @@
+import ArgumentParser
+import Foundation
+import VecturaKit
+import VecturaOAIKit
+
+@main
+struct VecturaOAICLI: AsyncParsableCommand {
+    struct DocumentID: ExpressibleByArgument, Decodable {
+        let uuid: UUID
+
+        init(_ uuid: UUID) {
+            self.uuid = uuid
+        }
+
+        init?(argument: String) {
+            guard let uuid = UUID(uuidString: argument) else { return nil }
+            self.uuid = uuid
+        }
+    }
+
+    struct ConnectionOptions: ParsableArguments {
+        @Option(name: [.long], help: "OpenAI-compatible base URL, for example http://localhost:1234/v1")
+        var baseURL: String = ProcessInfo.processInfo.environment["VECTURA_OAI_BASE_URL"] ?? "http://localhost:1234/v1"
+
+        @Option(name: [.long], help: "Embedding model identifier")
+        var model: String = ProcessInfo.processInfo.environment["VECTURA_OAI_MODEL"] ?? ""
+
+        @Option(name: [.long], help: "Optional API key")
+        var apiKey: String = ProcessInfo.processInfo.environment["VECTURA_OAI_API_KEY"] ?? ""
+
+        @Option(name: [.long], help: "Request timeout in seconds")
+        var timeout: Double = 120
+
+        @Option(name: [.long], help: "HTTP 429 retry attempts")
+        var retryAttempts: Int = 2
+
+        @Option(name: [.long], help: "Base retry delay in seconds")
+        var retryBaseDelay: Double = 1
+    }
+
+    static let configuration = CommandConfiguration(
+        commandName: "vectura-oai",
+        abstract: "A CLI tool for VecturaKit vector databases using OpenAI-compatible embeddings",
+        subcommands: [Add.self, Search.self, Update.self, Delete.self, Reset.self, Mock.self]
+    )
+
+    static func writeError(_ message: String) {
+        let errorMessage = message + "\n"
+        if let data = errorMessage.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+    }
+
+    static func setupDB(
+        dbName: String,
+        directory: String?,
+        dimension: Int? = nil,
+        numResults: Int = 10,
+        threshold: Float = 0.7,
+        connection: ConnectionOptions
+    ) async throws -> VecturaKit {
+        guard !connection.model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError("Missing embedding model. Pass --model or set VECTURA_OAI_MODEL.")
+        }
+
+        let directoryURL = directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+        let config = try VecturaConfig(
+            name: dbName,
+            directoryURL: directoryURL,
+            dimension: dimension,
+            searchOptions: .init(
+                defaultNumResults: numResults,
+                minThreshold: threshold
+            )
+        )
+
+        let embedder = OpenAICompatibleEmbedder(
+            baseURL: connection.baseURL,
+            model: connection.model,
+            apiKey: connection.apiKey.isEmpty ? nil : connection.apiKey,
+            timeoutInterval: connection.timeout,
+            retryAttempts: connection.retryAttempts,
+            retryBaseDelaySeconds: connection.retryBaseDelay
+        )
+
+        return try await VecturaKit(config: config, embedder: embedder)
+    }
+}
+
+extension VecturaOAICLI {
+    struct Mock: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Run a mock demonstration with sample data"
+        )
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        @Option(name: [.long, .customShort("t")], help: "Minimum similarity threshold")
+        var threshold: Float = 0.7
+
+        @Option(name: [.long, .customShort("n")], help: "Number of results to return")
+        var numResults: Int = 10
+
+        mutating func run() async throws {
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                numResults: numResults,
+                threshold: threshold,
+                connection: connection
+            )
+
+            try await db.reset()
+
+            let sampleTexts = [
+                "The quick brown fox jumps over the lazy dog",
+                "To be or not to be, that is the question",
+                "All that glitters is not gold",
+                "A journey of a thousand miles begins with a single step",
+                "Where there is smoke, there is fire",
+            ]
+
+            let ids = try await db.addDocuments(texts: sampleTexts)
+            print("Added \(ids.count) documents")
+
+            let results = try await db.search(query: .text("journey"), numResults: numResults, threshold: threshold)
+            print("Found \(results.count) results for 'journey'")
+            for result in results {
+                print("ID: \(result.id)")
+                print("Text: \(result.text)")
+                print("Score: \(result.score)")
+                print("---")
+            }
+        }
+    }
+
+    struct Add: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Add documents to the vector database")
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        @Argument(help: "Text content to add")
+        var text: [String]
+
+        mutating func run() async throws {
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                connection: connection
+            )
+            let ids = try await db.addDocuments(texts: text)
+            print("Added \(ids.count) documents:")
+            for (id, text) in zip(ids, text) {
+                print("ID: \(id)")
+                print("Text: \(text)")
+                print("---")
+            }
+        }
+    }
+
+    struct Search: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Search documents in the vector database")
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        @Option(name: [.long, .customShort("t")], help: "Minimum similarity threshold")
+        var threshold: Float?
+
+        @Option(name: [.long, .customShort("n")], help: "Number of results to return")
+        var numResults: Int?
+
+        @Argument(help: "Search query")
+        var query: String
+
+        mutating func run() async throws {
+            guard !query.isEmpty else {
+                VecturaOAICLI.writeError("Error: Query cannot be empty.")
+                throw ExitCode.failure
+            }
+
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                numResults: numResults ?? 10,
+                threshold: threshold ?? 0.7,
+                connection: connection
+            )
+
+            let results = try await db.search(
+                query: .text(query),
+                numResults: numResults,
+                threshold: threshold
+            )
+
+            print("Found \(results.count) results:")
+            for result in results {
+                print("ID: \(result.id)")
+                print("Text: \(result.text)")
+                print("Score: \(result.score)")
+                print("Created: \(result.createdAt)")
+                print("---")
+            }
+        }
+    }
+
+    struct Update: AsyncParsableCommand, Decodable {
+        static let configuration = CommandConfiguration(abstract: "Update a document in the vector database")
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        @Argument(help: "Document ID to update")
+        var id: DocumentID
+
+        @Argument(help: "New text content")
+        var newText: String
+
+        mutating func run() async throws {
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                connection: connection
+            )
+            try await db.updateDocument(id: id.uuid, newText: newText)
+            print("Updated document \(id.uuid)")
+        }
+    }
+
+    struct Delete: AsyncParsableCommand, Decodable {
+        static let configuration = CommandConfiguration(abstract: "Delete documents from the vector database")
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        @Argument(help: "Document IDs to delete")
+        var ids: [DocumentID]
+
+        mutating func run() async throws {
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                connection: connection
+            )
+            try await db.deleteDocuments(ids: ids.map(\.uuid))
+            print("Deleted \(ids.count) documents")
+        }
+    }
+
+    struct Reset: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Reset the vector database")
+
+        @OptionGroup var connection: ConnectionOptions
+
+        @Option(name: [.long, .customShort("d")], help: "Database name")
+        var dbName: String = "vectura-oai-cli-db"
+
+        @Option(name: [.long], help: "Database directory")
+        var directory: String?
+
+        @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if not specified)")
+        var dimension: Int?
+
+        mutating func run() async throws {
+            let db = try await VecturaOAICLI.setupDB(
+                dbName: dbName,
+                directory: directory,
+                dimension: dimension,
+                connection: connection
+            )
+            try await db.reset()
+            print("Database reset complete")
+        }
+    }
+}

--- a/Sources/VecturaOAIKit/OpenAICompatibleEmbedder.swift
+++ b/Sources/VecturaOAIKit/OpenAICompatibleEmbedder.swift
@@ -4,111 +4,141 @@ import VecturaKit
 
 /// A VecturaKit embedder that calls an OpenAI-compatible `/v1/embeddings` endpoint.
 public actor OpenAICompatibleEmbedder: VecturaEmbedder {
-    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vectura.oai", category: "embeddings")
-    private let baseURL: String
-    private let model: String
-    private let apiKey: String?
-    private let timeoutInterval: TimeInterval
-    private let retryAttempts: Int
-    private let retryBaseDelaySeconds: TimeInterval
-    private let session: URLSession
-    private var cachedDimension: Int?
+  private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vectura.oai", category: "embeddings")
+  private let baseURL: String
+  private let model: String
+  private let apiKey: String?
+  private let timeoutInterval: TimeInterval
+  private let retryAttempts: Int
+  private let retryBaseDelaySeconds: TimeInterval
+  private let session: URLSession
+  private var cachedDimension: Int?
 
-    public init(
-        baseURL: String,
-        model: String,
-        apiKey: String? = nil,
-        timeoutInterval: TimeInterval,
-        retryAttempts: Int,
-        retryBaseDelaySeconds: TimeInterval,
-        session: URLSession = .shared
-    ) {
-        self.baseURL = baseURL
-        self.model = model
-        self.apiKey = apiKey
-        self.timeoutInterval = timeoutInterval
-        self.retryAttempts = retryAttempts
-        self.retryBaseDelaySeconds = retryBaseDelaySeconds
-        self.session = session
+  public init(
+    baseURL: String,
+    model: String,
+    apiKey: String? = nil,
+    timeoutInterval: TimeInterval,
+    retryAttempts: Int,
+    retryBaseDelaySeconds: TimeInterval,
+    session: URLSession = .shared
+  ) {
+    self.baseURL = baseURL
+    self.model = model
+    self.apiKey = apiKey
+    self.timeoutInterval = timeoutInterval
+    self.retryAttempts = retryAttempts
+    self.retryBaseDelaySeconds = retryBaseDelaySeconds
+    self.session = session
+  }
+
+  public var dimension: Int {
+    get async throws {
+      if let cachedDimension {
+        return cachedDimension
+      }
+
+      let result = try await embed(texts: ["hello"])
+      let dimension = result.first?.count ?? 0
+      cachedDimension = dimension
+      return dimension
+    }
+  }
+
+  public func embed(texts: [String]) async throws -> [[Float]] {
+    guard !texts.isEmpty else {
+      throw OpenAICompatibleEmbedderError.invalidInput("Cannot embed empty array of texts")
     }
 
-    public var dimension: Int {
-        get async throws {
-            if let cachedDimension {
-                return cachedDimension
-            }
-
-            let result = try await embed(texts: ["hello"])
-            let dimension = result.first?.count ?? 0
-            cachedDimension = dimension
-            return dimension
-        }
-    }
-
-    public func embed(texts: [String]) async throws -> [[Float]] {
-        guard !texts.isEmpty else {
-            throw OpenAICompatibleEmbedderError.invalidInput("Cannot embed empty array of texts")
-        }
-
-        for (index, text) in texts.enumerated() {
-            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                throw OpenAICompatibleEmbedderError.invalidInput("Text at index \(index) cannot be empty or whitespace-only")
-            }
-        }
-
-        guard let url = URL(string: baseURL + "/embeddings") else {
-            throw OpenAICompatibleEmbedderError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = timeoutInterval
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let apiKey, !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-
-        let body: [String: Any] = ["model": model, "input": texts]
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let (data, response) = try await OpenAICompatibleRateLimitRetry.data(
-            for: request,
-            operation: "embeddings request",
-            logger: logger,
-            retryAttempts: retryAttempts,
-            retryBaseDelaySeconds: retryBaseDelaySeconds,
-            session: session
+    for (index, text) in texts.enumerated() {
+      guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        throw OpenAICompatibleEmbedderError.invalidInput(
+          "Text at index \(index) cannot be empty or whitespace-only"
         )
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              200..<300 ~= httpResponse.statusCode else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw OpenAICompatibleEmbedderError.httpError(statusCode: statusCode, message: errorMessage)
-        }
-
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let dataArray = json["data"] as? [[String: Any]] else {
-            throw OpenAICompatibleEmbedderError.httpError(statusCode: 0, message: "Invalid response format")
-        }
-
-        let embeddings = dataArray
-            .sorted { ($0["index"] as? Int ?? 0) < ($1["index"] as? Int ?? 0) }
-            .compactMap { item -> [Float]? in
-                guard let embedding = item["embedding"] as? [NSNumber] else {
-                    return nil
-                }
-                return embedding.map(\.floatValue)
-            }
-
-        guard embeddings.count == texts.count else {
-            throw OpenAICompatibleEmbedderError.vectorCountMismatch(expected: texts.count, received: embeddings.count)
-        }
-
-        if let dimension = embeddings.first?.count {
-            cachedDimension = dimension
-        }
-
-        return embeddings
+      }
     }
+
+    var request = URLRequest(url: try embeddingsURL())
+    request.httpMethod = "POST"
+    request.timeoutInterval = timeoutInterval
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    if let apiKey, !apiKey.isEmpty {
+      request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    }
+
+    let body: [String: Any] = ["model": model, "input": texts]
+    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+    let (data, response) = try await OpenAICompatibleRateLimitRetry.data(
+      for: request,
+      operation: "embeddings request",
+      logger: logger,
+      retryAttempts: retryAttempts,
+      retryBaseDelaySeconds: retryBaseDelaySeconds,
+      session: session
+    )
+
+    guard let httpResponse = response as? HTTPURLResponse,
+      200..<300 ~= httpResponse.statusCode
+    else {
+      let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+      let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+      throw OpenAICompatibleEmbedderError.httpError(statusCode: statusCode, message: errorMessage)
+    }
+
+    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let dataArray = json["data"] as? [[String: Any]]
+    else {
+      throw OpenAICompatibleEmbedderError.httpError(statusCode: 0, message: "Invalid response format")
+    }
+
+    let embeddings = dataArray
+      .sorted { ($0["index"] as? Int ?? 0) < ($1["index"] as? Int ?? 0) }
+      .compactMap { item -> [Float]? in
+        guard let embedding = item["embedding"] as? [NSNumber] else {
+          return nil
+        }
+        return embedding.map(\.floatValue)
+      }
+
+    guard embeddings.count == texts.count else {
+      throw OpenAICompatibleEmbedderError.vectorCountMismatch(expected: texts.count, received: embeddings.count)
+    }
+
+    if let dimension = embeddings.first?.count {
+      cachedDimension = dimension
+    }
+
+    return embeddings
+  }
+
+  private func embeddingsURL() throws -> URL {
+    let trimmedBaseURL = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      !trimmedBaseURL.isEmpty,
+      let rawURL = URL(string: trimmedBaseURL),
+      rawURL.scheme != nil,
+      var components = URLComponents(url: rawURL, resolvingAgainstBaseURL: false)
+    else {
+      throw OpenAICompatibleEmbedderError.invalidURL
+    }
+
+    let pathComponents = components.percentEncodedPath
+      .split(separator: "/", omittingEmptySubsequences: true)
+
+    if pathComponents.last == "embeddings" {
+      guard let url = components.url else {
+        throw OpenAICompatibleEmbedderError.invalidURL
+      }
+      return url
+    }
+
+    let updatedPath = "/" + (pathComponents + ["embeddings"]).joined(separator: "/")
+    components.percentEncodedPath = updatedPath
+
+    guard let url = components.url else {
+      throw OpenAICompatibleEmbedderError.invalidURL
+    }
+    return url
+  }
 }

--- a/Sources/VecturaOAIKit/OpenAICompatibleEmbedder.swift
+++ b/Sources/VecturaOAIKit/OpenAICompatibleEmbedder.swift
@@ -1,0 +1,114 @@
+import Foundation
+import OSLog
+import VecturaKit
+
+/// A VecturaKit embedder that calls an OpenAI-compatible `/v1/embeddings` endpoint.
+public actor OpenAICompatibleEmbedder: VecturaEmbedder {
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vectura.oai", category: "embeddings")
+    private let baseURL: String
+    private let model: String
+    private let apiKey: String?
+    private let timeoutInterval: TimeInterval
+    private let retryAttempts: Int
+    private let retryBaseDelaySeconds: TimeInterval
+    private let session: URLSession
+    private var cachedDimension: Int?
+
+    public init(
+        baseURL: String,
+        model: String,
+        apiKey: String? = nil,
+        timeoutInterval: TimeInterval,
+        retryAttempts: Int,
+        retryBaseDelaySeconds: TimeInterval,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.model = model
+        self.apiKey = apiKey
+        self.timeoutInterval = timeoutInterval
+        self.retryAttempts = retryAttempts
+        self.retryBaseDelaySeconds = retryBaseDelaySeconds
+        self.session = session
+    }
+
+    public var dimension: Int {
+        get async throws {
+            if let cachedDimension {
+                return cachedDimension
+            }
+
+            let result = try await embed(texts: ["hello"])
+            let dimension = result.first?.count ?? 0
+            cachedDimension = dimension
+            return dimension
+        }
+    }
+
+    public func embed(texts: [String]) async throws -> [[Float]] {
+        guard !texts.isEmpty else {
+            throw OpenAICompatibleEmbedderError.invalidInput("Cannot embed empty array of texts")
+        }
+
+        for (index, text) in texts.enumerated() {
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw OpenAICompatibleEmbedderError.invalidInput("Text at index \(index) cannot be empty or whitespace-only")
+            }
+        }
+
+        guard let url = URL(string: baseURL + "/embeddings") else {
+            throw OpenAICompatibleEmbedderError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeoutInterval
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = ["model": model, "input": texts]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await OpenAICompatibleRateLimitRetry.data(
+            for: request,
+            operation: "embeddings request",
+            logger: logger,
+            retryAttempts: retryAttempts,
+            retryBaseDelaySeconds: retryBaseDelaySeconds,
+            session: session
+        )
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              200..<300 ~= httpResponse.statusCode else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw OpenAICompatibleEmbedderError.httpError(statusCode: statusCode, message: errorMessage)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataArray = json["data"] as? [[String: Any]] else {
+            throw OpenAICompatibleEmbedderError.httpError(statusCode: 0, message: "Invalid response format")
+        }
+
+        let embeddings = dataArray
+            .sorted { ($0["index"] as? Int ?? 0) < ($1["index"] as? Int ?? 0) }
+            .compactMap { item -> [Float]? in
+                guard let embedding = item["embedding"] as? [NSNumber] else {
+                    return nil
+                }
+                return embedding.map(\.floatValue)
+            }
+
+        guard embeddings.count == texts.count else {
+            throw OpenAICompatibleEmbedderError.vectorCountMismatch(expected: texts.count, received: embeddings.count)
+        }
+
+        if let dimension = embeddings.first?.count {
+            cachedDimension = dimension
+        }
+
+        return embeddings
+    }
+}

--- a/Sources/VecturaOAIKit/OpenAICompatibleEmbedderError.swift
+++ b/Sources/VecturaOAIKit/OpenAICompatibleEmbedderError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum OpenAICompatibleEmbedderError: LocalizedError {
+    case invalidURL
+    case invalidInput(String)
+    case httpError(statusCode: Int, message: String)
+    case vectorCountMismatch(expected: Int, received: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid embedding endpoint URL."
+        case .invalidInput(let message):
+            return message
+        case .httpError(let statusCode, let message):
+            return "Embedding request failed (\(statusCode)): \(message)"
+        case .vectorCountMismatch(let expected, let received):
+            return "Expected \(expected) embedding vectors, received \(received)."
+        }
+    }
+}

--- a/Sources/VecturaOAIKit/OpenAICompatibleRateLimitRetry.swift
+++ b/Sources/VecturaOAIKit/OpenAICompatibleRateLimitRetry.swift
@@ -1,0 +1,117 @@
+import Foundation
+import OSLog
+
+enum OpenAICompatibleRateLimitRetry {
+    private static let maxRetryDelayNanoseconds: UInt64 = 30_000_000_000
+    private static let minimumRetryAttempts = 0
+    private static let maximumRetryAttempts = 6
+    private static let minimumRetryBaseDelaySeconds: TimeInterval = 1
+    private static let maximumRetryBaseDelaySeconds: TimeInterval = 30
+
+    private static let retryAfterDateFormatters: [DateFormatter] = {
+        let formats = [
+            "EEE',' dd MMM yyyy HH':'mm':'ss zzz",
+            "EEEE',' dd-MMM-yy HH':'mm':'ss zzz",
+            "EEE MMM d HH':'mm':'ss yyyy",
+        ]
+
+        return formats.map { format in
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = format
+            return formatter
+        }
+    }()
+
+    static func data(
+        for request: URLRequest,
+        operation: String,
+        logger: Logger,
+        retryAttempts: Int,
+        retryBaseDelaySeconds: TimeInterval,
+        session: URLSession
+    ) async throws -> (Data, URLResponse) {
+        let maxRetries = min(max(retryAttempts, minimumRetryAttempts), maximumRetryAttempts)
+
+        for attempt in 0...maxRetries {
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return (data, response)
+            }
+
+            guard httpResponse.statusCode == 429, attempt < maxRetries else {
+                return (data, response)
+            }
+
+            let retryNumber = attempt + 1
+            let delayNanoseconds = retryDelayNanoseconds(
+                retryNumber: retryNumber,
+                retryAfterHeader: httpResponse.value(forHTTPHeaderField: "Retry-After"),
+                retryBaseDelaySeconds: retryBaseDelaySeconds
+            )
+
+            logger.warning(
+                "OpenAI-compatible \(operation, privacy: .public) hit rate limit (retry \(retryNumber)/\(maxRetries)); retrying in \(formattedDelay(delayNanoseconds), privacy: .public)"
+            )
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+
+        return try await session.data(for: request)
+    }
+
+    private static func retryDelayNanoseconds(
+        retryNumber: Int,
+        retryAfterHeader: String?,
+        retryBaseDelaySeconds: TimeInterval
+    ) -> UInt64 {
+        if let headerDelay = retryAfterDelayNanoseconds(from: retryAfterHeader) {
+            return headerDelay
+        }
+
+        let exponent = min(max(retryNumber - 1, 0), 4)
+        let multiplier = UInt64(1 << exponent)
+        let baseDelayNanoseconds = nanoseconds(
+            fromSeconds: min(
+                max(retryBaseDelaySeconds, minimumRetryBaseDelaySeconds),
+                maximumRetryBaseDelaySeconds
+            )
+        )
+        return min(baseDelayNanoseconds * multiplier, maxRetryDelayNanoseconds)
+    }
+
+    private static func retryAfterDelayNanoseconds(from header: String?) -> UInt64? {
+        guard let trimmedHeader = header?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmedHeader.isEmpty else {
+            return nil
+        }
+
+        if let seconds = Double(trimmedHeader), seconds > 0 {
+            return nanoseconds(fromSeconds: seconds)
+        }
+
+        for formatter in retryAfterDateFormatters {
+            if let retryDate = formatter.date(from: trimmedHeader) {
+                let seconds = retryDate.timeIntervalSinceNow
+                guard seconds > 0 else {
+                    return nil
+                }
+                return nanoseconds(fromSeconds: seconds)
+            }
+        }
+
+        return nil
+    }
+
+    private static func nanoseconds(fromSeconds seconds: TimeInterval) -> UInt64 {
+        let nanoseconds = seconds * 1_000_000_000
+        let rounded = UInt64(max(0, nanoseconds.rounded()))
+        return min(rounded, maxRetryDelayNanoseconds)
+    }
+
+    private static func formattedDelay(_ nanoseconds: UInt64) -> String {
+        let seconds = Double(nanoseconds) / 1_000_000_000
+        return String(format: "%.2fs", seconds)
+    }
+}

--- a/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
+++ b/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import XCTest
+@testable import VecturaOAIKit
+
+final class OpenAICompatibleEmbedderTests: XCTestCase {
+    func testEmbedPostsExpectedPayloadAndSortsVectorsByIndex() async throws {
+        MockURLProtocol.setHandler { request in
+            XCTAssertEqual(request.url?.absoluteString, "http://localhost:1234/v1/embeddings")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer secret")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+            let body = try XCTUnwrap(readRequestBody(from: request))
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(json["model"] as? String, "text-embedding-3-small")
+            XCTAssertEqual(json["input"] as? [String], ["first", "second"])
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                """
+                {
+                  "data": [
+                    { "index": 1, "embedding": [3.0, 4.0] },
+                    { "index": 0, "embedding": [1.0, 2.0] }
+                  ]
+                }
+                """.utf8
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.setHandler(nil) }
+
+        let embedder = OpenAICompatibleEmbedder(
+            baseURL: "http://localhost:1234/v1",
+            model: "text-embedding-3-small",
+            apiKey: "secret",
+            timeoutInterval: 5,
+            retryAttempts: 2,
+            retryBaseDelaySeconds: 1,
+            session: makeSession()
+        )
+
+        let embeddings = try await embedder.embed(texts: ["first", "second"])
+
+        XCTAssertEqual(embeddings.count, 2)
+        XCTAssertEqual(embeddings[0], [1.0, 2.0])
+        XCTAssertEqual(embeddings[1], [3.0, 4.0])
+    }
+
+    func testDimensionIsCachedAfterFirstRequest() async throws {
+        let requestCount = CounterBox()
+        MockURLProtocol.setHandler { request in
+            requestCount.value += 1
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"data":[{"index":0,"embedding":[1.0,2.0,3.0]}]}"#.utf8)
+            return (response, data)
+        }
+        defer { MockURLProtocol.setHandler(nil) }
+
+        let embedder = OpenAICompatibleEmbedder(
+            baseURL: "http://localhost:1234/v1",
+            model: "text-embedding-3-small",
+            timeoutInterval: 5,
+            retryAttempts: 0,
+            retryBaseDelaySeconds: 1,
+            session: makeSession()
+        )
+
+        let first = try await embedder.dimension
+        let second = try await embedder.dimension
+
+        XCTAssertEqual(first, 3)
+        XCTAssertEqual(second, 3)
+        XCTAssertEqual(requestCount.value, 1)
+    }
+
+    func testEmbedRetriesAfterRateLimit() async throws {
+        let requestCount = CounterBox()
+        MockURLProtocol.setHandler { request in
+            requestCount.value += 1
+
+            if requestCount.value == 1 {
+                let response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 429,
+                    httpVersion: nil,
+                    headerFields: ["Retry-After": "0.001"]
+                )!
+                return (response, Data("rate limited".utf8))
+            }
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(#"{"data":[{"index":0,"embedding":[42.0]}]}"#.utf8)
+            return (response, data)
+        }
+        defer { MockURLProtocol.setHandler(nil) }
+
+        let embedder = OpenAICompatibleEmbedder(
+            baseURL: "http://localhost:1234/v1",
+            model: "text-embedding-3-small",
+            timeoutInterval: 5,
+            retryAttempts: 1,
+            retryBaseDelaySeconds: 1,
+            session: makeSession()
+        )
+
+        let embeddings = try await embedder.embed(texts: ["retry me"])
+
+        XCTAssertEqual(requestCount.value, 2)
+        XCTAssertEqual(embeddings, [[42.0]])
+    }
+
+    func testEmbedRejectsWhitespaceOnlyInput() async {
+        defer { MockURLProtocol.setHandler(nil) }
+
+        let embedder = OpenAICompatibleEmbedder(
+            baseURL: "http://localhost:1234/v1",
+            model: "text-embedding-3-small",
+            timeoutInterval: 5,
+            retryAttempts: 0,
+            retryBaseDelaySeconds: 1,
+            session: makeSession()
+        )
+
+        do {
+            _ = try await embedder.embed(texts: ["   "])
+            XCTFail("Expected invalid input error")
+        } catch let error as OpenAICompatibleEmbedderError {
+            guard case .invalidInput(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.contains("index 0"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    private static let storage = RequestHandlerStorage()
+
+    static func setHandler(_ handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        storage.set(handler)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            let (response, data) = try Self.storage.handle(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class RequestHandlerStorage: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requestHandler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    func set(_ handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?) {
+        lock.lock()
+        defer { lock.unlock() }
+        requestHandler = handler
+    }
+
+    func handle(_ request: URLRequest) throws -> (HTTPURLResponse, Data) {
+        lock.lock()
+        let requestHandler = requestHandler
+        lock.unlock()
+
+        guard let requestHandler else {
+            throw NSError(domain: "MockURLProtocol", code: -1)
+        }
+        return try requestHandler(request)
+    }
+}
+
+private final class CounterBox: @unchecked Sendable {
+    var value = 0
+}
+
+private func readRequestBody(from request: URLRequest) -> Data? {
+    if let httpBody = request.httpBody {
+        return httpBody
+    }
+
+    guard let stream = request.httpBodyStream else {
+        return nil
+    }
+
+    stream.open()
+    defer { stream.close() }
+
+    let bufferSize = 1024
+    var data = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+
+    while stream.hasBytesAvailable {
+        let read = stream.read(buffer, maxLength: bufferSize)
+        guard read > 0 else { break }
+        data.append(buffer, count: read)
+    }
+
+    return data.isEmpty ? nil : data
+}

--- a/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
+++ b/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
@@ -48,6 +48,56 @@ struct OpenAICompatibleEmbedderTests {
     #expect(embeddings[1] == [3.0, 4.0])
   }
 
+  @Test("Builds the embeddings endpoint from a trailing-slash base URL")
+  func embedBuildsEndpointFromTrailingSlashBaseURL() async throws {
+    MockURLProtocol.setHandler { request in
+      #expect(request.url?.absoluteString == "http://localhost:1234/v1/embeddings")
+
+      let url = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )
+      )
+      let data = Data(#"{"data":[{"index":0,"embedding":[1.0,2.0]}]}"#.utf8)
+      return (response, data)
+    }
+    defer { MockURLProtocol.setHandler(nil) }
+
+    let embedder = makeEmbedder(baseURL: "http://localhost:1234/v1/")
+    let embeddings = try await embedder.embed(texts: ["first"])
+
+    #expect(embeddings == [[1.0, 2.0]])
+  }
+
+  @Test("Accepts a fully qualified embeddings endpoint without duplicating the path")
+  func embedAcceptsFullyQualifiedEmbeddingsEndpoint() async throws {
+    MockURLProtocol.setHandler { request in
+      #expect(request.url?.absoluteString == "http://localhost:1234/custom/v1/embeddings")
+
+      let url = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
+        )
+      )
+      let data = Data(#"{"data":[{"index":0,"embedding":[3.0,4.0]}]}"#.utf8)
+      return (response, data)
+    }
+    defer { MockURLProtocol.setHandler(nil) }
+
+    let embedder = makeEmbedder(baseURL: "http://localhost:1234/custom/v1/embeddings")
+    let embeddings = try await embedder.embed(texts: ["first"])
+
+    #expect(embeddings == [[3.0, 4.0]])
+  }
+
   @Test("Caches the detected dimension after the first request")
   func dimensionIsCachedAfterFirstRequest() async throws {
     let requestCount = CounterBox()
@@ -128,6 +178,7 @@ struct OpenAICompatibleEmbedderTests {
   }
 
   private func makeEmbedder(
+    baseURL: String = "http://localhost:1234/v1",
     apiKey: String? = nil,
     retryAttempts: Int = 0
   ) -> OpenAICompatibleEmbedder {
@@ -136,7 +187,7 @@ struct OpenAICompatibleEmbedderTests {
     let session = URLSession(configuration: configuration)
 
     return OpenAICompatibleEmbedder(
-      baseURL: "http://localhost:1234/v1",
+      baseURL: baseURL,
       model: "text-embedding-3-small",
       apiKey: apiKey,
       timeoutInterval: 5,

--- a/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
+++ b/Tests/VecturaOAIKitTests/OpenAICompatibleEmbedderTests.swift
@@ -1,160 +1,150 @@
 import Foundation
-import XCTest
+import Testing
 @testable import VecturaOAIKit
 
-final class OpenAICompatibleEmbedderTests: XCTestCase {
-    func testEmbedPostsExpectedPayloadAndSortsVectorsByIndex() async throws {
-        MockURLProtocol.setHandler { request in
-            XCTAssertEqual(request.url?.absoluteString, "http://localhost:1234/v1/embeddings")
-            XCTAssertEqual(request.httpMethod, "POST")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer secret")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+@Suite("OpenAICompatibleEmbedder", .serialized)
+struct OpenAICompatibleEmbedderTests {
+  @Test("POSTs the expected payload and sorts vectors by index")
+  func embedPostsExpectedPayloadAndSortsVectorsByIndex() async throws {
+    MockURLProtocol.setHandler { request in
+      #expect(request.url?.absoluteString == "http://localhost:1234/v1/embeddings")
+      #expect(request.httpMethod == "POST")
+      #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+      #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
 
-            let body = try XCTUnwrap(readRequestBody(from: request))
-            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
-            XCTAssertEqual(json["model"] as? String, "text-embedding-3-small")
-            XCTAssertEqual(json["input"] as? [String], ["first", "second"])
+      let body = try #require(readRequestBody(from: request))
+      let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+      #expect(json["model"] as? String == "text-embedding-3-small")
+      #expect(json["input"] as? [String] == ["first", "second"])
 
-            let response = HTTPURLResponse(
-                url: try XCTUnwrap(request.url),
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            let data = Data(
-                """
-                {
-                  "data": [
-                    { "index": 1, "embedding": [3.0, 4.0] },
-                    { "index": 0, "embedding": [1.0, 2.0] }
-                  ]
-                }
-                """.utf8
-            )
-            return (response, data)
-        }
-        defer { MockURLProtocol.setHandler(nil) }
-
-        let embedder = OpenAICompatibleEmbedder(
-            baseURL: "http://localhost:1234/v1",
-            model: "text-embedding-3-small",
-            apiKey: "secret",
-            timeoutInterval: 5,
-            retryAttempts: 2,
-            retryBaseDelaySeconds: 1,
-            session: makeSession()
+      let url = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
         )
-
-        let embeddings = try await embedder.embed(texts: ["first", "second"])
-
-        XCTAssertEqual(embeddings.count, 2)
-        XCTAssertEqual(embeddings[0], [1.0, 2.0])
-        XCTAssertEqual(embeddings[1], [3.0, 4.0])
-    }
-
-    func testDimensionIsCachedAfterFirstRequest() async throws {
-        let requestCount = CounterBox()
-        MockURLProtocol.setHandler { request in
-            requestCount.value += 1
-            let response = HTTPURLResponse(
-                url: try XCTUnwrap(request.url),
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            let data = Data(#"{"data":[{"index":0,"embedding":[1.0,2.0,3.0]}]}"#.utf8)
-            return (response, data)
+      )
+      let data = Data(
+        """
+        {
+          "data": [
+            { "index": 1, "embedding": [3.0, 4.0] },
+            { "index": 0, "embedding": [1.0, 2.0] }
+          ]
         }
-        defer { MockURLProtocol.setHandler(nil) }
+        """.utf8
+      )
+      return (response, data)
+    }
+    defer { MockURLProtocol.setHandler(nil) }
 
-        let embedder = OpenAICompatibleEmbedder(
-            baseURL: "http://localhost:1234/v1",
-            model: "text-embedding-3-small",
-            timeoutInterval: 5,
-            retryAttempts: 0,
-            retryBaseDelaySeconds: 1,
-            session: makeSession()
+    let embedder = makeEmbedder(apiKey: "secret", retryAttempts: 2)
+    let embeddings = try await embedder.embed(texts: ["first", "second"])
+
+    #expect(embeddings.count == 2)
+    #expect(embeddings[0] == [1.0, 2.0])
+    #expect(embeddings[1] == [3.0, 4.0])
+  }
+
+  @Test("Caches the detected dimension after the first request")
+  func dimensionIsCachedAfterFirstRequest() async throws {
+    let requestCount = CounterBox()
+    MockURLProtocol.setHandler { request in
+      requestCount.value += 1
+
+      let url = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
         )
-
-        let first = try await embedder.dimension
-        let second = try await embedder.dimension
-
-        XCTAssertEqual(first, 3)
-        XCTAssertEqual(second, 3)
-        XCTAssertEqual(requestCount.value, 1)
+      )
+      let data = Data(#"{"data":[{"index":0,"embedding":[1.0,2.0,3.0]}]}"#.utf8)
+      return (response, data)
     }
+    defer { MockURLProtocol.setHandler(nil) }
 
-    func testEmbedRetriesAfterRateLimit() async throws {
-        let requestCount = CounterBox()
-        MockURLProtocol.setHandler { request in
-            requestCount.value += 1
+    let embedder = makeEmbedder()
+    let first = try await embedder.dimension
+    let second = try await embedder.dimension
 
-            if requestCount.value == 1 {
-                let response = HTTPURLResponse(
-                    url: try XCTUnwrap(request.url),
-                    statusCode: 429,
-                    httpVersion: nil,
-                    headerFields: ["Retry-After": "0.001"]
-                )!
-                return (response, Data("rate limited".utf8))
-            }
+    #expect(first == 3)
+    #expect(second == 3)
+    #expect(requestCount.value == 1)
+  }
 
-            let response = HTTPURLResponse(
-                url: try XCTUnwrap(request.url),
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            let data = Data(#"{"data":[{"index":0,"embedding":[42.0]}]}"#.utf8)
-            return (response, data)
-        }
-        defer { MockURLProtocol.setHandler(nil) }
+  @Test("Retries once after a rate-limit response")
+  func embedRetriesAfterRateLimit() async throws {
+    let requestCount = CounterBox()
+    MockURLProtocol.setHandler { request in
+      requestCount.value += 1
 
-        let embedder = OpenAICompatibleEmbedder(
-            baseURL: "http://localhost:1234/v1",
-            model: "text-embedding-3-small",
-            timeoutInterval: 5,
-            retryAttempts: 1,
-            retryBaseDelaySeconds: 1,
-            session: makeSession()
+      let url = try #require(request.url)
+      if requestCount.value == 1 {
+        let response = try #require(
+          HTTPURLResponse(
+            url: url,
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": "0.001"]
+          )
         )
+        return (response, Data("rate limited".utf8))
+      }
 
-        let embeddings = try await embedder.embed(texts: ["retry me"])
-
-        XCTAssertEqual(requestCount.value, 2)
-        XCTAssertEqual(embeddings, [[42.0]])
-    }
-
-    func testEmbedRejectsWhitespaceOnlyInput() async {
-        defer { MockURLProtocol.setHandler(nil) }
-
-        let embedder = OpenAICompatibleEmbedder(
-            baseURL: "http://localhost:1234/v1",
-            model: "text-embedding-3-small",
-            timeoutInterval: 5,
-            retryAttempts: 0,
-            retryBaseDelaySeconds: 1,
-            session: makeSession()
+      let response = try #require(
+        HTTPURLResponse(
+          url: url,
+          statusCode: 200,
+          httpVersion: nil,
+          headerFields: nil
         )
-
-        do {
-            _ = try await embedder.embed(texts: ["   "])
-            XCTFail("Expected invalid input error")
-        } catch let error as OpenAICompatibleEmbedderError {
-            guard case .invalidInput(let message) = error else {
-                return XCTFail("Unexpected error: \(error)")
-            }
-            XCTAssertTrue(message.contains("index 0"))
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+      )
+      let data = Data(#"{"data":[{"index":0,"embedding":[42.0]}]}"#.utf8)
+      return (response, data)
     }
+    defer { MockURLProtocol.setHandler(nil) }
 
-    private func makeSession() -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [MockURLProtocol.self]
-        return URLSession(configuration: configuration)
+    let embedder = makeEmbedder(retryAttempts: 1)
+    let embeddings = try await embedder.embed(texts: ["retry me"])
+
+    #expect(requestCount.value == 2)
+    #expect(embeddings == [[42.0]])
+  }
+
+  @Test("Rejects whitespace-only input")
+  func embedRejectsWhitespaceOnlyInput() async {
+    defer { MockURLProtocol.setHandler(nil) }
+
+    let embedder = makeEmbedder()
+
+    await #expect(throws: OpenAICompatibleEmbedderError.self) {
+      _ = try await embedder.embed(texts: ["   "])
     }
+  }
+
+  private func makeEmbedder(
+    apiKey: String? = nil,
+    retryAttempts: Int = 0
+  ) -> OpenAICompatibleEmbedder {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    let session = URLSession(configuration: configuration)
+
+    return OpenAICompatibleEmbedder(
+      baseURL: "http://localhost:1234/v1",
+      model: "text-embedding-3-small",
+      apiKey: apiKey,
+      timeoutInterval: 5,
+      retryAttempts: retryAttempts,
+      retryBaseDelaySeconds: 1,
+      session: session
+    )
+  }
 }
 
 private final class MockURLProtocol: URLProtocol {


### PR DESCRIPTION
## Summary
- add `VecturaOAIKit` as a sibling library target in `VecturaKit`
- move `vectura-oai-cli`, the OpenAI-compatible example target, and OAI tests into this package
- document the built-in OpenAI-compatible integration and note that the standalone `VecturaOAIKit` repo is intended to be deprecated after merge

## Verification
- `swift test --filter VecturaOAIKitTests`
- `swift test` (new OAI tests pass, but the full suite still hits pre-existing local model asset failures under `/Users/sriram/Documents/huggingface/models/...`, unrelated to this change)
