### PR TITLE
[codex] Restore NaturalLanguage CLI support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-VecturaKit ships as a Swift package with libraries `VecturaKit` (core storage + hybrid search), `VecturaNLKit` (NaturalLanguage embeddings), and `VecturaOAIKit` (OpenAI-compatible embeddings), plus CLI target `VecturaOAICLI`. Sample executables live in `Sources/TestOAIExamples` and `Sources/TestNLExamples`. Tests live under `Tests/VecturaKitTests`, `Tests/VecturaNLKitTests`, and `Tests/VecturaOAIKitTests`. `SwiftEmbedder` support lives in [rryam/VecturaEmbeddingsKit](https://github.com/rryam/VecturaEmbeddingsKit), and MLX support lives in [rryam/VecturaMLXKit](https://github.com/rryam/VecturaMLXKit).
+VecturaKit ships as a Swift package with libraries `VecturaKit` (core storage + hybrid search), `VecturaNLKit` (NaturalLanguage embeddings), and `VecturaOAIKit` (OpenAI-compatible embeddings), plus CLI targets `VecturaCLI` and `VecturaOAICLI`. Sample executables live in `Sources/TestExamples`, `Sources/TestNLExamples`, and `Sources/TestOAIExamples`. Tests live under `Tests/VecturaKitTests`, `Tests/VecturaNLKitTests`, `Tests/VecturaOAIKitTests`, and `Tests/PerformanceTests`. `SwiftEmbedder` support lives in [rryam/VecturaEmbeddingsKit](https://github.com/rryam/VecturaEmbeddingsKit), and MLX support lives in [rryam/VecturaMLXKit](https://github.com/rryam/VecturaMLXKit).
 
 ## Build, Test, and Development Commands
 - `swift build` compiles libraries and executables (add `-c release` for performance validation).
+- `swift run vectura-cli mock --db-name demo-db --directory /tmp/vectura-cli-demo` seeds and exercises the NaturalLanguage CLI path.
 - `swift run vectura-oai-cli mock --db-name demo-db --model <model>` seeds and exercises the OpenAI-compatible engine.
 - `swift test` runs the Swift Testing suites; add `--filter SuiteName/TestName` to narrow scope.
 - `swift package update` refreshes dependency pins before release branches or large upgrades.
@@ -22,6 +23,7 @@ Commits stay imperative and scoped (`Add cosine similarity guard`, `Adjust CLI m
 Before opening a PR (or completing an automated change):
 
 - [ ] `swift build` and `swift test` succeed locally without warnings.
+- [ ] Run `swift run vectura-cli mock --db-name qa-db --directory /tmp/vectura-cli-qa-db` when behavior touches the NaturalLanguage CLI path.
 - [ ] Run `swift run vectura-oai-cli mock --db-name qa-db --model <model>` when behavior touches the OpenAI-compatible CLI.
 - [ ] Persistent storage defaults and dimension negotiation stay intact—verify hybrid search thresholds and expected `VecturaError.dimensionMismatch` behavior.
 - [ ] Public API or CLI flag changes are reflected in `README.md`, `codemagic.yaml`, and this guide.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -88,7 +88,7 @@ Docs/
 **Additional Resources:**
 - **Performance Tests:** [Tests/PerformanceTests/](../Tests/PerformanceTests/) - Run your own benchmarks
 - **Main README:** [../README.md](../README.md) - Project overview and quick start
-- **Examples:** [Sources/TestNLExamples/](../Sources/TestNLExamples/) and [Sources/TestOAIExamples/](../Sources/TestOAIExamples/) - Sample code
+- **Examples:** [Sources/TestExamples/](../Sources/TestExamples/), [Sources/TestNLExamples/](../Sources/TestNLExamples/), and [Sources/TestOAIExamples/](../Sources/TestOAIExamples/) - Sample code
 
 ---
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
       targets: ["VecturaNLKit"]
     ),
     .executable(
+      name: "vectura-cli",
+      targets: ["VecturaCLI"]
+    ),
+    .executable(
       name: "vectura-oai-cli",
       targets: ["VecturaOAICLI"]
     ),
@@ -54,11 +58,26 @@ let package = Package(
       ]
     ),
     .executableTarget(
+      name: "VecturaCLI",
+      dependencies: [
+        "VecturaKit",
+        "VecturaNLKit",
+        .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]
+    ),
+    .executableTarget(
       name: "VecturaOAICLI",
       dependencies: [
         "VecturaKit",
         "VecturaOAIKit",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ]
+    ),
+    .executableTarget(
+      name: "TestExamples",
+      dependencies: [
+        "VecturaKit",
+        "VecturaNLKit",
       ]
     ),
     .executableTarget(
@@ -83,7 +102,10 @@ let package = Package(
     ),
     .testTarget(
       name: "PerformanceTests",
-      dependencies: ["VecturaKit"],
+      dependencies: [
+        "VecturaKit",
+        "VecturaNLKit",
+      ],
       resources: [
         .copy("README.md"),
         .copy("ArchivedResults"),

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inspired by [Dripfarm's SVDB](https://github.com/Dripfarm/SVDB), **VecturaKit** 
 
 The framework offers `VecturaKit` as the core vector database with pluggable embedding providers. Use `OpenAICompatibleEmbedder` for hosted or local `/v1/embeddings` providers, `NLContextualEmbedder` for Apple's NaturalLanguage framework with zero external dependencies, [`SwiftEmbedder`](https://github.com/rryam/VecturaEmbeddingsKit) for `swift-embeddings` models, or [`MLXEmbedder`](https://github.com/rryam/VecturaMLXKit) for Apple's MLX framework acceleration.
 
-It also includes `vectura-oai-cli` for trying OpenAI-compatible embedding providers from the command line.
+It also includes `vectura-cli` for NaturalLanguage-backed local workflows and `vectura-oai-cli` for trying OpenAI-compatible embedding providers from the command line.
 
 <p align="center">
   <img src="https://img.shields.io/badge/Swift-6.0+-fa7343?style=flat&logo=swift&logoColor=white" alt="Swift 6.0+">
@@ -61,6 +61,7 @@ Explore the following books to understand more about AI and iOS development:
   - [Search Documents](#nl-search-documents)
   - [Document Management](#nl-document-management)
 - [Command Line Interface](#command-line-interface)
+  - [NaturalLanguage CLI Tool (`vectura-cli`)](#naturallanguage-cli-tool-vectura-cli)
   - [OpenAI-Compatible CLI Tool (`vectura-oai-cli`)](#openai-compatible-cli-tool-vectura-oai-cli)
 - [License](#license)
 - [Contributing](#contributing)
@@ -83,7 +84,7 @@ Explore the following books to understand more about AI and iOS development:
 -   **MLX Support:** GPU-accelerated embedding generation available via the separate [VecturaMLXKit](https://github.com/rryam/VecturaMLXKit) package.
 -   **OpenAI-Compatible Support:** Connects to OpenAI-compatible `/v1/embeddings` endpoints exposed by local servers and hosted providers through `OpenAICompatibleEmbedder`.
 -   **NaturalLanguage Support:** Uses Apple's NaturalLanguage framework for contextual embeddings with zero external dependencies through `NLContextualEmbedder`.
--   **CLI Tools:** Includes `vectura-oai-cli` for OpenAI-compatible database management and testing.
+-   **CLI Tools:** Includes `vectura-cli` for NaturalLanguage-backed local workflows and `vectura-oai-cli` for OpenAI-compatible database management and testing.
 
 ## Supported Platforms
 
@@ -633,19 +634,40 @@ try await vectorDB.reset()
 
 ## Command Line Interface
 
-VecturaKit includes an OpenAI-compatible CLI for database management.
+VecturaKit includes command-line tools for NaturalLanguage-backed local workflows and OpenAI-compatible embedding providers.
+
+### NaturalLanguage CLI Tool (`vectura-cli`)
+
+`vectura-cli` uses `VecturaNLKit`, so it can run local mock workflows without a hosted embedding server.
+
+```bash
+vectura-cli add "First document" "Second document" --language english
+vectura-cli search "search query" --language english --threshold 0.7 --num-results 5
+vectura-cli update <document-uuid> "Updated text" --language english
+vectura-cli delete <document-uuid-1> <document-uuid-2> --language english
+vectura-cli reset --language english
+vectura-cli mock --db-name demo-db --directory /tmp/vectura-cli-demo
+```
+
+Common options for `vectura-cli`:
+
+-   `--db-name, -d`: Database name (default: `"vectura-cli-db"`)
+-   `--directory`: Database directory (optional)
+-   `--language`: NaturalLanguage embedding language (default: `english`)
+-   `--threshold, -t`: Minimum similarity threshold (default: `0.7`)
+-   `--num-results, -n`: Number of results to return (default: `10`)
 
 ### OpenAI-Compatible CLI Tool (`vectura-oai-cli`)
 
 Set `VECTURA_OAI_BASE_URL` and `VECTURA_OAI_MODEL`, or pass `--base-url` and `--model` directly.
 
 ```bash
-vectura-oai add "First document" "Second document" --model text-embedding-model
-vectura-oai search "search query" --model text-embedding-model --threshold 0.7 --num-results 5
-vectura-oai update <document-uuid> "Updated text" --model text-embedding-model
-vectura-oai delete <document-uuid-1> <document-uuid-2> --model text-embedding-model
-vectura-oai reset --model text-embedding-model
-vectura-oai mock --model text-embedding-model
+vectura-oai-cli add "First document" "Second document" --model text-embedding-model
+vectura-oai-cli search "search query" --model text-embedding-model --threshold 0.7 --num-results 5
+vectura-oai-cli update <document-uuid> "Updated text" --model text-embedding-model
+vectura-oai-cli delete <document-uuid-1> <document-uuid-2> --model text-embedding-model
+vectura-oai-cli reset --model text-embedding-model
+vectura-oai-cli mock --model text-embedding-model
 ```
 
 Common options for `vectura-oai-cli`:

--- a/Sources/TestExamples/TestExamples.swift
+++ b/Sources/TestExamples/TestExamples.swift
@@ -1,0 +1,86 @@
+import Foundation
+import VecturaKit
+import VecturaNLKit
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+@main
+struct ValidationScript {
+  enum ValidationError: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+      switch self {
+      case .message(let text):
+        return text
+      }
+    }
+  }
+
+  static func main() async {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("VecturaKit-TestExamples-\(UUID().uuidString)", isDirectory: true)
+
+    do {
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: directory) }
+
+      let config = try VecturaConfig(
+        name: "validation-db",
+        directoryURL: directory,
+        searchOptions: VecturaConfig.SearchOptions(
+          defaultNumResults: 5,
+          minThreshold: 0.1
+        )
+      )
+
+      let embedder = try await NLContextualEmbedder(language: .english)
+      let vectorDB = try await VecturaKit(config: config, embedder: embedder)
+      try await vectorDB.reset()
+
+      let texts = [
+        "VecturaKit combines vector similarity with BM25 text search for hybrid retrieval.",
+        "Swift is the primary language for building apps on Apple platforms like iOS and macOS.",
+        "Vector databases store embeddings to power semantic search over text.",
+        "On-device search keeps user data private and responsive.",
+      ]
+
+      let ids = try await vectorDB.addDocuments(texts: texts)
+      guard ids.count == texts.count else {
+        throw ValidationError.message("Document count mismatch: expected \(texts.count), got \(ids.count).")
+      }
+
+      let hybridResults = try await vectorDB.search(query: .text("hybrid search"), numResults: 3)
+      try validateResults(label: "Hybrid search", results: hybridResults, expectedSubstring: "BM25")
+
+      let semanticResults = try await vectorDB.search(query: .text("Apple platform development"), numResults: 3)
+      try validateResults(label: "Semantic search", results: semanticResults, expectedSubstring: "Swift")
+
+      let vectorEmbedding = try await embedder.embed(text: "semantic search with embeddings")
+      let vectorResults = try await vectorDB.search(query: .vector(vectorEmbedding), numResults: 3)
+      try validateResults(label: "Vector search", results: vectorResults, expectedSubstring: "embeddings")
+
+      print("VecturaKit NL examples completed successfully.")
+    } catch {
+      print("Validation failed: \(error)")
+      exit(1)
+    }
+  }
+
+  private static func validateResults(
+    label: String,
+    results: [VecturaSearchResult],
+    expectedSubstring: String
+  ) throws {
+    guard !results.isEmpty else {
+      throw ValidationError.message("\(label): no results returned.")
+    }
+
+    let hasExpected = results.prefix(3).contains { result in
+      result.text.localizedCaseInsensitiveContains(expectedSubstring)
+    }
+
+    guard hasExpected else {
+      throw ValidationError.message("\(label): expected a result containing '\(expectedSubstring)'.")
+    }
+  }
+}

--- a/Sources/VecturaCLI/VecturaCLI.swift
+++ b/Sources/VecturaCLI/VecturaCLI.swift
@@ -1,0 +1,435 @@
+import ArgumentParser
+import Foundation
+import NaturalLanguage
+import VecturaKit
+import VecturaNLKit
+
+struct MockDataset {
+  struct Category {
+    let name: String
+    let documents: [String]
+  }
+
+  let categories: [Category]
+
+  var totalDocuments: Int {
+    categories.reduce(0) { $0 + $1.documents.count }
+  }
+
+  var allDocuments: [String] {
+    categories.flatMap(\.documents)
+  }
+
+  static let `default` = MockDataset(categories: [
+    Category(name: "Technology", documents: [
+      "Apple platforms rely on Swift for app development across iPhone, iPad, Mac, Apple TV, and Vision Pro.",
+      "Semantic search combines vector similarity with lexical ranking to improve retrieval quality.",
+      "Distributed systems use queues, caches, and retry strategies to keep latency predictable.",
+      "Mobile teams measure p95 latency and crash-free sessions before shipping major releases.",
+    ]),
+    Category(name: "Science", documents: [
+      "Astronomers analyze light from distant galaxies to understand how the universe expands.",
+      "Molecular biology studies proteins, RNA, and DNA interactions inside living cells.",
+      "Climate scientists model atmospheric warming, ocean circulation, and carbon emissions.",
+      "Robotics blends control systems, perception, and planning for physical automation.",
+    ]),
+    Category(name: "Business", documents: [
+      "Product managers align roadmap priorities with customer feedback and technical constraints.",
+      "Leadership principles matter when teams need clear decisions during incidents.",
+      "Healthy teams write down operating procedures before scaling support rotations.",
+      "Finance organizations track cash flow, revenue quality, and cost efficiency over time.",
+    ]),
+    Category(name: "Creative", documents: [
+      "Creative writing workshops encourage revision, feedback, and careful scene construction.",
+      "Historical fiction often uses archival research to ground imagined dialogue in real events.",
+      "Storytelling works better when conflict, pacing, and character motivation stay coherent.",
+      "Music theory explains harmony, rhythm, melody, and tonal movement across styles.",
+    ]),
+  ])
+}
+
+private extension String {
+  static func * (left: String, right: Int) -> String {
+    String(repeating: left, count: right)
+  }
+}
+
+private extension Duration {
+  var timeInterval: TimeInterval {
+    let (seconds, attoseconds) = components
+    return TimeInterval(seconds) + (TimeInterval(attoseconds) / 1e18)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+@main
+struct VecturaCLI: AsyncParsableCommand {
+  struct DocumentID: ExpressibleByArgument {
+    let uuid: UUID
+
+    init?(argument: String) {
+      guard let uuid = UUID(uuidString: argument) else { return nil }
+      self.uuid = uuid
+    }
+  }
+
+  struct LanguageOption: ExpressibleByArgument {
+    let language: NLLanguage
+
+    init?(argument: String) {
+      let normalized = argument.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      switch normalized {
+      case "en", "english":
+        language = .english
+      case "es", "spanish":
+        language = .spanish
+      case "fr", "french":
+        language = .french
+      case "de", "german":
+        language = .german
+      case "it", "italian":
+        language = .italian
+      case "pt", "portuguese":
+        language = .portuguese
+      default:
+        language = NLLanguage(rawValue: normalized)
+      }
+    }
+  }
+
+  static let configuration = CommandConfiguration(
+    commandName: "vectura",
+    abstract: "A CLI tool for VecturaKit using NaturalLanguage embeddings",
+    subcommands: [Add.self, Search.self, Update.self, Delete.self, Reset.self, Mock.self]
+  )
+
+  static func writeError(_ message: String) {
+    guard let data = (message + "\n").data(using: .utf8) else { return }
+    FileHandle.standardError.write(data)
+  }
+
+  static func setupDB(
+    dbName: String,
+    directoryURL: URL?,
+    dimension: Int?,
+    numResults: Int,
+    threshold: Float,
+    language: NLLanguage
+  ) async throws -> VecturaKit {
+    let config = try VecturaConfig(
+      name: dbName,
+      directoryURL: directoryURL,
+      dimension: dimension,
+      searchOptions: VecturaConfig.SearchOptions(
+        defaultNumResults: numResults,
+        minThreshold: threshold
+      )
+    )
+    let embedder = try await NLContextualEmbedder(language: language)
+    return try await VecturaKit(config: config, embedder: embedder)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+extension VecturaCLI {
+  struct Mock: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+      abstract: "Run a local demo with NaturalLanguage embeddings"
+    )
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-demo-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("t")], help: "Minimum similarity threshold for searches")
+    var threshold: Float = 0.5
+
+    @Option(name: [.long, .customShort("n")], help: "Number of results to return per search")
+    var numResults: Int = 5
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    mutating func run() async throws {
+      print("VecturaKit Mock Demonstration")
+      print("=" * 60)
+
+      let dataset = MockDataset.default
+      print("\nLoaded \(dataset.totalDocuments) documents across \(dataset.categories.count) categories")
+      for category in dataset.categories {
+        print("  \(category.name): \(category.documents.count)")
+      }
+
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: numResults,
+        threshold: threshold,
+        language: language.language
+      )
+
+      try await db.reset()
+
+      print("\nIndexing documents...")
+      let start = ContinuousClock.now
+      let ids = try await db.addDocuments(texts: dataset.allDocuments)
+      let duration = ContinuousClock.now - start
+      let docsPerSecond = Double(ids.count) / max(duration.timeInterval, 0.001)
+      print(
+        "Indexed \(ids.count) documents in \(String(format: "%.2f", duration.timeInterval))s "
+          + "(\(String(format: "%.1f", docsPerSecond)) docs/sec)"
+      )
+
+      let queries = [
+        "swift app development",
+        "leadership decisions",
+        "molecular biology",
+        "creative storytelling",
+      ]
+
+      for query in queries {
+        print("\n" + "-" * 60)
+        print("Query: \(query)")
+        let results = try await db.search(
+          query: .text(query),
+          numResults: numResults,
+          threshold: threshold
+        )
+        if results.isEmpty {
+          print("No results")
+          continue
+        }
+
+        for (index, result) in results.enumerated() {
+          let preview = String(result.text.prefix(90))
+          print("\(index + 1). [\(String(format: "%.3f", result.score))] \(preview)")
+        }
+      }
+
+      print("\nFinal document count: \(try await db.documentCount)")
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+
+  struct Add: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Add documents to the vector database")
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    @Argument(help: "Text content to add")
+    var text: [String]
+
+    mutating func run() async throws {
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: 10,
+        threshold: 0.7,
+        language: language.language
+      )
+
+      let ids = try await db.addDocuments(texts: text)
+      for (id, value) in zip(ids, text) {
+        print("ID: \(id)")
+        print("Text: \(value)")
+        print("---")
+      }
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+
+  struct Search: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Search documents in the vector database")
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("t")], help: "Minimum similarity threshold")
+    var threshold: Float = 0.7
+
+    @Option(name: [.long, .customShort("n")], help: "Number of results to return")
+    var numResults: Int = 10
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    @Argument(help: "Search query")
+    var query: String
+
+    mutating func run() async throws {
+      guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        VecturaCLI.writeError("Error: Query cannot be empty.")
+        throw ExitCode.failure
+      }
+
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: numResults,
+        threshold: threshold,
+        language: language.language
+      )
+      let results = try await db.search(
+        query: .text(query),
+        numResults: numResults,
+        threshold: threshold
+      )
+
+      for result in results {
+        print("ID: \(result.id)")
+        print("Text: \(result.text)")
+        print("Score: \(result.score)")
+        print("Created: \(result.createdAt)")
+        print("---")
+      }
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+
+  struct Update: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Update a document in the vector database")
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    @Argument(help: "Document ID to update")
+    var id: DocumentID
+
+    @Argument(help: "New text content")
+    var newText: String
+
+    mutating func run() async throws {
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: 10,
+        threshold: 0.7,
+        language: language.language
+      )
+      try await db.updateDocument(id: id.uuid, newText: newText)
+      print("Updated document \(id.uuid)")
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+
+  struct Delete: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Delete documents from the vector database")
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    @Argument(help: "Document IDs to delete")
+    var ids: [DocumentID]
+
+    mutating func run() async throws {
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: 10,
+        threshold: 0.7,
+        language: language.language
+      )
+      try await db.deleteDocuments(ids: ids.map(\.uuid))
+      print("Deleted \(ids.count) documents")
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+
+  struct Reset: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Reset the vector database")
+
+    @Option(name: [.long, .customShort("d")], help: "Database name")
+    var dbName: String = "vectura-cli-db"
+
+    @Option(name: .long, help: "Optional database directory")
+    var directory: String?
+
+    @Option(name: [.long, .customShort("v")], help: "Vector dimension (auto-detected if omitted)")
+    var dimension: Int?
+
+    @Option(name: [.long, .customShort("l")], help: "Embedding language, for example en or english")
+    var language: LanguageOption = .init(language: .english)
+
+    mutating func run() async throws {
+      let db = try await VecturaCLI.setupDB(
+        dbName: dbName,
+        directoryURL: directoryURL,
+        dimension: dimension,
+        numResults: 10,
+        threshold: 0.7,
+        language: language.language
+      )
+      try await db.reset()
+      print("Database reset successfully")
+    }
+
+    private var directoryURL: URL? {
+      directory.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+  }
+}
+
+private extension VecturaCLI.LanguageOption {
+  init(language: NLLanguage) {
+    self.language = language
+  }
+}

--- a/Sources/VecturaKit/Storage/FileStorageProvider.swift
+++ b/Sources/VecturaKit/Storage/FileStorageProvider.swift
@@ -77,10 +77,8 @@ extension FileStorageProvider: VecturaStorage {
 
   /// Returns total document count without decoding all document files.
   public func getTotalDocumentCount() async throws -> Int {
-    if cacheEnabled && cacheIsFullyLoaded {
-      return cache.count
-    }
-
+    // Count directly from disk because overlapping loads and writes can temporarily leave
+    // the cache in a stale-but-fully-loaded state.
     let fileURLs = try FileManager.default.contentsOfDirectory(
       at: storageDirectory,
       includingPropertiesForKeys: nil

--- a/Tests/PerformanceTests/Helpers/PerformanceTestConfig.swift
+++ b/Tests/PerformanceTests/Helpers/PerformanceTestConfig.swift
@@ -1,8 +1,12 @@
 import Foundation
 @testable import VecturaKit
+@testable import VecturaNLKit
 
 enum PerformanceTestConfig {
   private static let environment = ProcessInfo.processInfo.environment
+
+  static let useNLEmbedder: Bool =
+    environment["VECTURA_PERF_USE_NL_EMBEDDER"] == "1"
 
   static let performanceProfile: String =
     (environment["VECTURA_PERF_PROFILE"] ?? "default").lowercased()
@@ -12,17 +16,21 @@ enum PerformanceTestConfig {
 
   static let defaultDimension = 384
   static let realisticDocumentCount =
-    intEnv("VECTURA_PERF_REALISTIC_DOCS", default: 12_000)
+    intEnv("VECTURA_PERF_REALISTIC_DOCS", default: useNLEmbedder ? 2_500 : 12_000)
   static let realisticQueryCount =
-    intEnv("VECTURA_PERF_REALISTIC_QUERIES", default: 600)
+    intEnv("VECTURA_PERF_REALISTIC_QUERIES", default: useNLEmbedder ? 160 : 600)
   static let realisticMixedOperationCount =
-    intEnv("VECTURA_PERF_REALISTIC_MIXED_OPS", default: 1_200)
+    intEnv("VECTURA_PERF_REALISTIC_MIXED_OPS", default: useNLEmbedder ? 240 : 1_200)
   static let realisticConcurrentClients =
-    intEnv("VECTURA_PERF_REALISTIC_CLIENTS", default: 12)
+    intEnv("VECTURA_PERF_REALISTIC_CLIENTS", default: useNLEmbedder ? 4 : 12)
   static let realisticColdRuns =
-    intEnv("VECTURA_PERF_REALISTIC_COLD_RUNS", default: 24)
+    intEnv("VECTURA_PERF_REALISTIC_COLD_RUNS", default: useNLEmbedder ? 6 : 24)
 
-  static func makeEmbedder() -> any VecturaEmbedder {
+  @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+  static func makeEmbedder() async throws -> any VecturaEmbedder {
+    if useNLEmbedder {
+      return try await NLContextualEmbedder(language: .english)
+    }
     return DeterministicEmbedder(dimensionValue: defaultDimension)
   }
 

--- a/Tests/PerformanceTests/README.md
+++ b/Tests/PerformanceTests/README.md
@@ -73,10 +73,10 @@ Tests/PerformanceTests/
 ### Embedder Selection (Speed vs Realism)
 
 By default, performance tests use a deterministic embedder to keep runtimes short and avoid
-downloading CoreML models. To run with real embeddings, set:
+depending on platform embedding model behavior. To run with real NaturalLanguage embeddings, set:
 
 ```bash
-VECTURA_PERF_USE_SWIFT_EMBEDDER=1
+VECTURA_PERF_USE_NL_EMBEDDER=1
 ```
 
 ### Realistic Profile (Harder Benchmark Mode)

--- a/Tests/PerformanceTests/Suites/AccuracyTests.swift
+++ b/Tests/PerformanceTests/Suites/AccuracyTests.swift
@@ -90,7 +90,7 @@ struct AccuracyTests {
     )
     let baselineVectura = try await VecturaKit(
       config: config1,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
 
     // Generate consistent UUIDs for documents
@@ -109,7 +109,7 @@ struct AccuracyTests {
     let mockStorage = MockIndexedStorage()
     let indexedVectura = try await VecturaKit(
       config: config2,
-      embedder: PerformanceTestConfig.makeEmbedder(),
+      embedder: try await PerformanceTestConfig.makeEmbedder(),
       storageProvider: mockStorage
     )
     // Use the same document IDs to ensure comparison is valid
@@ -153,7 +153,7 @@ struct AccuracyTests {
     let generator = TestDataGenerator()
     let documents = generator.generateDocuments(count: documentCount, seed: 12345)
     let queries = generator.generateQueries(count: 10, seed: 54321)
-    let embedder = PerformanceTestConfig.makeEmbedder()
+    let embedder = try await PerformanceTestConfig.makeEmbedder()
 
     // Generate consistent UUIDs for documents
     let documentIds = (0..<documentCount).map { _ in UUID() }
@@ -239,7 +239,7 @@ struct AccuracyTests {
     let generator = TestDataGenerator()
     let documents = generator.generateDocuments(count: documentCount, seed: 12345)
     let queries = generator.generateQueries(count: 10, seed: 54321)
-    let embedder = PerformanceTestConfig.makeEmbedder()
+    let embedder = try await PerformanceTestConfig.makeEmbedder()
 
     // Generate consistent UUIDs for documents
     let documentIds = (0..<documentCount).map { _ in UUID() }
@@ -365,7 +365,7 @@ struct AccuracyTests {
     )
     let baselineVectura = try await VecturaKit(
       config: config1,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
 
     // Generate consistent UUIDs for documents
@@ -384,7 +384,7 @@ struct AccuracyTests {
     let mockStorage = MockIndexedStorage()
     let indexedVectura = try await VecturaKit(
       config: config2,
-      embedder: PerformanceTestConfig.makeEmbedder(),
+      embedder: try await PerformanceTestConfig.makeEmbedder(),
       storageProvider: mockStorage
     )
     // Use the same document IDs to ensure comparison is valid

--- a/Tests/PerformanceTests/Suites/BenchmarkSuite.swift
+++ b/Tests/PerformanceTests/Suites/BenchmarkSuite.swift
@@ -61,7 +61,7 @@ struct BenchmarkSuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
     let initTime = await monitor.getElapsed()
     await monitor.updateMemoryUsage()

--- a/Tests/PerformanceTests/Suites/MemoryProfilerSuite.swift
+++ b/Tests/PerformanceTests/Suites/MemoryProfilerSuite.swift
@@ -81,7 +81,7 @@ struct MemoryProfilerSuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
     memorySnapshots.append(("After Init", getCurrentMemoryMB()))
 
@@ -139,7 +139,7 @@ struct MemoryProfilerSuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
     memorySnapshots.append(("After Init", getCurrentMemoryMB()))
 
@@ -202,7 +202,7 @@ struct MemoryProfilerSuite {
       )
       let vectura = try await VecturaKit(
         config: config,
-        embedder: PerformanceTestConfig.makeEmbedder()
+        embedder: try await PerformanceTestConfig.makeEmbedder()
       )
       _ = try await vectura.addDocuments(texts: documents)
 
@@ -227,7 +227,7 @@ struct MemoryProfilerSuite {
       )
       let vectura = try await VecturaKit(
         config: config,
-        embedder: PerformanceTestConfig.makeEmbedder()
+        embedder: try await PerformanceTestConfig.makeEmbedder()
       )
       _ = try await vectura.addDocuments(texts: documents)
 
@@ -276,7 +276,7 @@ struct MemoryProfilerSuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
 
     // Add documents
@@ -337,7 +337,7 @@ struct MemoryProfilerSuite {
       )
       let vectura = try await VecturaKit(
         config: config,
-        embedder: PerformanceTestConfig.makeEmbedder()
+        embedder: try await PerformanceTestConfig.makeEmbedder()
       )
       _ = try await vectura.addDocuments(texts: documents)
 

--- a/Tests/PerformanceTests/Suites/ParameterTuningSuite.swift
+++ b/Tests/PerformanceTests/Suites/ParameterTuningSuite.swift
@@ -84,7 +84,7 @@ struct ParameterTuningSuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
     let initTime = await monitor.getElapsed()
     await monitor.updateMemoryUsage()

--- a/Tests/PerformanceTests/Suites/RealisticWorkloadSuite.swift
+++ b/Tests/PerformanceTests/Suites/RealisticWorkloadSuite.swift
@@ -98,7 +98,7 @@ struct RealisticWorkloadSuite {
     )
     return try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
   }
 

--- a/Tests/PerformanceTests/Suites/ScalabilitySuite.swift
+++ b/Tests/PerformanceTests/Suites/ScalabilitySuite.swift
@@ -62,7 +62,7 @@ struct ScalabilitySuite {
     )
     let vectura = try await VecturaKit(
       config: config,
-      embedder: PerformanceTestConfig.makeEmbedder()
+      embedder: try await PerformanceTestConfig.makeEmbedder()
     )
     let initTime = await monitor.getElapsed()
     await monitor.updateMemoryUsage()

--- a/Tests/VecturaNLKitTests/NLContextualEmbedderAdapterTests.swift
+++ b/Tests/VecturaNLKitTests/NLContextualEmbedderAdapterTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import VecturaKit
+@testable import VecturaNLKit
+
+@Suite("NLContextualEmbedder Adapter")
+struct NLContextualEmbedderAdapterTests {
+  private func makeDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("NLContextualEmbedderAdapterTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o755]
+    )
+    return directory
+  }
+
+  @Test("Batch embedding rejects empty element")
+  func batchEmbeddingRejectsEmptyElement() async throws {
+    let embedder = try await NLContextualEmbedder(language: .english)
+
+    await #expect(throws: NLContextualEmbedderError.self) {
+      _ = try await embedder.embed(texts: ["valid", ""])
+    }
+  }
+
+  @Test("Vector queries work with NL embeddings")
+  func vectorQueriesWork() async throws {
+    let directory = try makeDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let embedder = try await NLContextualEmbedder(language: .english)
+    let config = try VecturaConfig(name: "nl-adapter-db", directoryURL: directory)
+    let kit = try await VecturaKit(config: config, embedder: embedder)
+
+    _ = try await kit.addDocuments(texts: [
+      "SwiftUI powers user interfaces on Apple platforms.",
+      "Relational databases use tables, indexes, and transactions.",
+      "Vector search finds semantically similar content.",
+    ])
+
+    let queryEmbedding = try await embedder.embed(text: "Apple app development")
+    let results = try await kit.search(query: .vector(queryEmbedding), numResults: 2)
+
+    let first = try #require(results.first)
+    #expect(first.text.localizedCaseInsensitiveContains("Apple"))
+  }
+}

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -25,13 +25,24 @@ definitions:
       script: |
         #!/bin/zsh
 
-        # Set environment variables for model downloads
-        export HF_HUB_OFFLINE=0
-
         # Run core tests (excluding PerformanceTests)
-        # Using --no-parallel to avoid concurrent model download issues
         swift test --no-parallel \
           --skip PerformanceTests
+    - &run_vectura_cli_smoke
+      name: Run vectura-cli Smoke Test
+      script: |
+        #!/bin/zsh
+
+        export VECTURA_TMP_DB="$CM_BUILD_DIR/.codemagic-vectura-cli-db"
+        rm -rf "$VECTURA_TMP_DB"
+
+        swift run vectura-cli mock \
+          --db-name codemagic-qa-db \
+          --directory "$VECTURA_TMP_DB" \
+          --threshold 0.4 \
+          --num-results 3
+
+        rm -rf "$VECTURA_TMP_DB"
     - &run_realistic_perf_tests
       name: Run Realistic Performance Tests (Optional)
       script: |
@@ -50,7 +61,7 @@ definitions:
         export VECTURA_PERF_REALISTIC_COLD_RUNS="${VECTURA_PERF_REALISTIC_COLD_RUNS:-10}"
 
         # Keep deterministic embedder by default for CI stability/speed.
-        export VECTURA_PERF_USE_SWIFT_EMBEDDER="${VECTURA_PERF_USE_SWIFT_EMBEDDER:-0}"
+        export VECTURA_PERF_USE_NL_EMBEDDER="${VECTURA_PERF_USE_NL_EMBEDDER:-0}"
 
         swift test --no-parallel \
           --filter RealisticWorkloadSuite
@@ -73,4 +84,5 @@ workflows:
       - *swiftlint
       - *build_framework
       - *run_tests
+      - *run_vectura_cli_smoke
       - *run_realistic_perf_tests


### PR DESCRIPTION
## Summary
- restore the in-package NaturalLanguage-backed `vectura-cli` executable and `TestExamples` target on top of upstream `main`
- keep upstream's expanded performance suites while adding an opt-in `VECTURA_PERF_USE_NL_EMBEDDER=1` path
- restore NL adapter coverage, CLI docs/CI smoke coverage, and direct disk counting for `FileStorageProvider.getTotalDocumentCount()`

## Verification
- `swift build`
- `swift test --skip PerformanceTests`
- `swift run vectura-cli mock --db-name qa-db --directory /tmp/vectura-cli-qa-db --threshold 0.4 --num-results 3`
- `swift test --filter BenchmarkSuite.smallDatasetFullMemory`
