### PR TITLE
[codex] Avoid full corpus loads for indexed text search

### DIFF
--- a/Sources/VecturaKit/SearchEngine/BM25SearchEngine.swift
+++ b/Sources/VecturaKit/SearchEngine/BM25SearchEngine.swift
@@ -65,11 +65,14 @@ public actor BM25SearchEngine: VecturaSearchEngine {
       throw VecturaError.invalidInput("BM25 only supports text queries")
     }
 
-    // Future enhancement: Detect storage-layer text search capability
-    // Example:
-    // if let textSearchable = storage as? TextSearchableStorage {
-    //     return try await textSearchable.searchText(query: queryText, topK: options.numResults)
-    // }
+    if let indexedStorage = storage as? IndexedVecturaStorage,
+      let indexedResults = try await indexedStorage.searchText(
+        query: queryText,
+        topK: options.numResults
+      )
+    {
+      return applyThreshold(options.threshold, to: indexedResults)
+    }
 
     // Rebuild index if needed (first search or after documents changed)
     if index == nil || needsRebuild {
@@ -85,13 +88,7 @@ public actor BM25SearchEngine: VecturaSearchEngine {
 
     let results = await index.search(query: queryText, topK: options.numResults)
 
-    // Filter by threshold
-    var filteredResults = results
-    if let threshold = options.threshold {
-      filteredResults = results.filter { $0.score >= threshold }
-    }
-
-    return filteredResults.map { result in
+    let searchResults = results.map { result in
       VecturaSearchResult(
         id: result.document.id,
         text: result.document.text,
@@ -99,6 +96,7 @@ public actor BM25SearchEngine: VecturaSearchEngine {
         createdAt: result.document.createdAt
       )
     }
+    return applyThreshold(options.threshold, to: searchResults)
   }
 
   public func indexDocument(_ document: VecturaDocument) async throws {
@@ -151,5 +149,15 @@ public actor BM25SearchEngine: VecturaSearchEngine {
     get async {
       await index?.documentCount ?? 0
     }
+  }
+
+  private func applyThreshold(
+    _ threshold: Float?,
+    to results: [VecturaSearchResult]
+  ) -> [VecturaSearchResult] {
+    guard let threshold else {
+      return results
+    }
+    return results.filter { $0.score >= threshold }
   }
 }

--- a/Sources/VecturaKit/Storage/IndexedVecturaStorage.swift
+++ b/Sources/VecturaKit/Storage/IndexedVecturaStorage.swift
@@ -79,6 +79,23 @@ public protocol IndexedVecturaStorage: VecturaStorage {
     prefilterSize: Int
   ) async throws -> [UUID]?
 
+  /// Searches text candidates using a storage-layer text index.
+  ///
+  /// This optional capability lets indexed storage providers answer BM25/text
+  /// queries without forcing `BM25SearchEngine` to load every full document.
+  /// Providers without native text indexing can return `nil`, allowing callers
+  /// to fall back to their existing in-memory behavior.
+  ///
+  /// - Parameters:
+  ///   - query: The text query to search.
+  ///   - topK: Maximum number of ranked text results to return.
+  /// - Returns: Ranked text results, or `nil` if storage-layer text search is unsupported.
+  /// - Throws: Storage errors if text search fails.
+  func searchText(
+    query: String,
+    topK: Int
+  ) async throws -> [VecturaSearchResult]?
+
   /// Loads specific documents by their IDs.
   ///
   /// This is the second stage of indexed search, where only the candidate documents
@@ -88,4 +105,13 @@ public protocol IndexedVecturaStorage: VecturaStorage {
   /// - Returns: Dictionary mapping IDs to their documents (may not include all requested IDs if some don't exist)
   /// - Throws: Storage errors if loading fails
   func loadDocuments(ids: [UUID]) async throws -> [UUID: VecturaDocument]
+}
+
+extension IndexedVecturaStorage {
+  public func searchText(
+    query: String,
+    topK: Int
+  ) async throws -> [VecturaSearchResult]? {
+    nil
+  }
 }

--- a/Tests/VecturaKitTests/IndexedSearchPathTests.swift
+++ b/Tests/VecturaKitTests/IndexedSearchPathTests.swift
@@ -12,6 +12,9 @@ struct IndexedSearchPathTests {
     let loadDocumentsCalled: Bool
     let loadDocumentsIdsCalls: Int
     let lastLoadedIds: [UUID]
+    let searchTextCalls: Int
+    let lastTextQuery: String?
+    let lastTextTopK: Int?
   }
 
   private struct FixedEmbedder: VecturaEmbedder {
@@ -29,16 +32,25 @@ struct IndexedSearchPathTests {
   private actor IndexedStorageSpy: IndexedVecturaStorage {
     private let documents: [VecturaDocument]
     private let candidateIdsToReturn: [UUID]?
+    private let textResultsToReturn: [VecturaSearchResult]?
     private var searchVectorCandidatesCalls = 0
     private var lastTopK: Int?
     private var lastPrefilterSize: Int?
     private var loadDocumentsCalled = false
     private var loadDocumentsIdsCalls = 0
     private var lastLoadedIds: [UUID] = []
+    private var searchTextCalls = 0
+    private var lastTextQuery: String?
+    private var lastTextTopK: Int?
 
-    init(documents: [VecturaDocument], candidateIdsToReturn: [UUID]?) {
+    init(
+      documents: [VecturaDocument],
+      candidateIdsToReturn: [UUID]?,
+      textResultsToReturn: [VecturaSearchResult]? = nil
+    ) {
       self.documents = documents
       self.candidateIdsToReturn = candidateIdsToReturn
+      self.textResultsToReturn = textResultsToReturn
     }
 
     func snapshot() -> IndexedStorageSnapshot {
@@ -48,7 +60,10 @@ struct IndexedSearchPathTests {
         lastPrefilterSize: lastPrefilterSize,
         loadDocumentsCalled: loadDocumentsCalled,
         loadDocumentsIdsCalls: loadDocumentsIdsCalls,
-        lastLoadedIds: lastLoadedIds
+        lastLoadedIds: lastLoadedIds,
+        searchTextCalls: searchTextCalls,
+        lastTextQuery: lastTextQuery,
+        lastTextTopK: lastTextTopK
       )
     }
 
@@ -78,6 +93,16 @@ struct IndexedSearchPathTests {
       lastTopK = topK
       lastPrefilterSize = prefilterSize
       return candidateIdsToReturn
+    }
+
+    func searchText(
+      query: String,
+      topK: Int
+    ) async throws -> [VecturaSearchResult]? {
+      searchTextCalls += 1
+      lastTextQuery = query
+      lastTextTopK = topK
+      return textResultsToReturn
     }
 
     func loadDocuments(ids: [UUID]) async throws -> [UUID: VecturaDocument] {
@@ -139,5 +164,80 @@ struct IndexedSearchPathTests {
     #expect(snapshot.loadDocumentsCalled == true)
     #expect(snapshot.loadDocumentsIdsCalls == 1)
     #expect(Set(snapshot.lastLoadedIds) == Set([doc1.id, doc2.id]))
+  }
+
+  @Test("BM25 uses indexed text search without loading all documents")
+  func bm25UsesIndexedTextSearchWithoutLoadingAllDocuments() async throws {
+    let doc1 = VecturaDocument(id: UUID(), text: "indexed text match", embedding: [1.0, 0.0])
+    let doc2 = VecturaDocument(id: UUID(), text: "other corpus entry", embedding: [0.0, 1.0])
+    let expectedResult = VecturaSearchResult(
+      id: doc1.id,
+      text: doc1.text,
+      score: 3.0,
+      createdAt: doc1.createdAt
+    )
+    let storage = IndexedStorageSpy(
+      documents: [doc1, doc2],
+      candidateIdsToReturn: [doc1.id],
+      textResultsToReturn: [expectedResult]
+    )
+    let engine = BM25SearchEngine()
+
+    let results = try await engine.search(
+      query: .text("indexed text"),
+      storage: storage,
+      options: try SearchOptions(numResults: 1)
+    )
+
+    #expect(results.count == 1)
+    #expect(results.first?.id == expectedResult.id)
+    #expect(results.first?.text == expectedResult.text)
+    #expect(results.first?.score == expectedResult.score)
+    let snapshot = await storage.snapshot()
+    #expect(snapshot.searchTextCalls == 1)
+    #expect(snapshot.lastTextQuery == "indexed text")
+    #expect(snapshot.lastTextTopK == 1)
+    #expect(snapshot.loadDocumentsCalled == false)
+  }
+
+  @Test("Hybrid indexed text search does not load the full corpus")
+  func hybridIndexedTextSearchDoesNotLoadFullCorpus() async throws {
+    let doc1 = VecturaDocument(id: UUID(), text: "hybrid indexed match", embedding: [1.0, 0.0])
+    let doc2 = VecturaDocument(id: UUID(), text: "another document", embedding: [0.0, 1.0])
+    let textResult = VecturaSearchResult(
+      id: doc1.id,
+      text: doc1.text,
+      score: 4.0,
+      createdAt: doc1.createdAt
+    )
+    let storage = IndexedStorageSpy(
+      documents: [doc1, doc2],
+      candidateIdsToReturn: [doc1.id],
+      textResultsToReturn: [textResult]
+    )
+    let vectorEngine = VectorSearchEngine(
+      embedder: FixedEmbedder(embedding: [1.0, 0.0]),
+      strategy: .indexed(candidateMultiplier: 2, batchSize: 10, maxConcurrentBatches: 1)
+    )
+    let hybrid = HybridSearchEngine(
+      vectorEngine: vectorEngine,
+      textEngine: BM25SearchEngine(),
+      vectorWeight: 0.5,
+      bm25NormalizationFactor: 10.0
+    )
+
+    let results = try await hybrid.search(
+      query: .text("hybrid indexed"),
+      storage: storage,
+      options: try SearchOptions(numResults: 1)
+    )
+
+    #expect(results.first?.id == doc1.id)
+    let snapshot = await storage.snapshot()
+    #expect(snapshot.searchVectorCandidatesCalls == 1)
+    #expect(snapshot.searchTextCalls == 1)
+    #expect(snapshot.loadDocumentsCalled == false)
+    #expect(snapshot.loadDocumentsIdsCalls == 1)
+    #expect(snapshot.lastLoadedIds == [doc1.id])
   }
 }


### PR DESCRIPTION
## Summary
- add an optional indexed storage text-search hook for native text indexes
- route BM25 through that hook before falling back to in-memory corpus indexing
- add focused BM25 and hybrid indexed-path tests proving text queries do not call full-corpus load when indexed text search is available

## Validation
- swift test --filter IndexedSearchPathTests
- swift test
- swift build