### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,4 +696,4 @@ Contributions are welcome! Please fork the repository and submit a pull request 
 - [Discussions](https://github.com/rryam/VecturaKit/discussions)
 - [Twitter](https://x.com/rudrankriyam)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=rryam/VecturaKit&type=Date)](https://star-history.com/#rryam/VecturaKit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=rryam/VecturaKit&type=Date)](https://star-history.dera.page/#rryam/VecturaKit&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This updates the chart to use a working alternative so it renders correctly again.